### PR TITLE
Account for the size of HTTP headers

### DIFF
--- a/analysis/BUILD
+++ b/analysis/BUILD
@@ -36,6 +36,7 @@ py_binary(
     name = "analyzer",
     srcs = [
         "analyzer.py",
+        "network_models.py",
         "simulation.py",
     ],
     srcs_version = "PY3",

--- a/analysis/BUILD
+++ b/analysis/BUILD
@@ -36,8 +36,6 @@ py_binary(
     name = "analyzer",
     srcs = [
         "analyzer.py",
-        "network_models.py",
-        "simulation.py",
     ],
     srcs_version = "PY3",
     deps = [
@@ -45,10 +43,28 @@ py_binary(
         ":fake_pfe",
         ":page_view_sequence_proto_py",
         ":result_proto_py",
+        ":simulation",
         "//analysis/pfe_methods",
         "//patch_subset/py",
         "@io_abseil_py//absl:app",
         "@io_abseil_py//absl/flags",
+    ],
+)
+
+py_library(
+    name = "simulation",
+    srcs = [
+        "network_models.py",
+        "simulation.py",
+    ],
+    srcs_version = "PY3",
+    visibility = [
+        "//analysis/pfe_methods:__pkg__",
+        "//patch_subset/py:__pkg__",
+    ],
+    deps = [
+        ":common",
+        ":page_view_sequence_proto_py",
     ],
 )
 

--- a/analysis/analyzer.py
+++ b/analysis/analyzer.py
@@ -18,6 +18,7 @@ from absl import app
 from absl import flags
 from analysis import cost
 from analysis import distribution
+from analysis import network_models
 from analysis import page_view_sequence_pb2
 from analysis import result_pb2
 from analysis import simulation
@@ -47,17 +48,8 @@ PFE_METHODS = [
 ]
 
 NETWORK_MODELS = [
-    # TODO(garretrieger): populate with some real network models.
-    simulation.NetworkModel(
-        "broadband",
-        rtt=20,  # 40 ms
-        bandwidth_up=1250,  # 10 mbps
-        bandwidth_down=6250),  # 50 mbps
-    simulation.NetworkModel(
-        "dialup",
-        rtt=200,  # 200 ms
-        bandwidth_up=7,  # 56 kbps
-        bandwidth_down=7),  # 56 kbps
+    network_models.BROADBAND,
+    network_models.DIALUP,
 ]
 
 
@@ -127,7 +119,7 @@ class Analyzer:
 
     return method_result_proto
 
-  def analyze_data_set(self, data_set, pfe_methods, network_models,
+  def analyze_data_set(self, data_set, pfe_methods, the_network_models,
                        font_directory):
     """Analyze data set against the provided set of pfe_methods and network_models.
 
@@ -136,7 +128,8 @@ class Analyzer:
     """
     sequences = [sequence.page_views for sequence in data_set.sequences]
     simulation_results = simulation.simulate_all(sequences, pfe_methods,
-                                                 network_models, font_directory)
+                                                 the_network_models,
+                                                 font_directory)
 
     results = []
     for key, totals in sorted(simulation_results.items()):

--- a/analysis/network_models.py
+++ b/analysis/network_models.py
@@ -1,0 +1,33 @@
+"""Provides a set of network models.
+
+A network model is defined as the estimated round trip time, upstream bandwidth,
+and downstream bandwidth. This module defines several different models that
+attempt to estimate the behaviour of networks in use by users.
+"""
+
+from analysis import simulation
+
+# Estimated size of a http request header in bytes for a HTTP2 request using HPACK.
+#
+# Based on observing request header sizes for sample requests to a fonts CDN.
+#
+# This estimate is the steady state size, the size of an average request after
+# several previous requests have been made and the header dictionary has been
+# populated.
+ESTIMATED_HTTP_REQUEST_HEADER_SIZE = 35
+
+# Estimated size of a http response header in bytes for a HTTP2 response using HPACK.
+ESTIMATED_HTTP_RESPONSE_HEADER_SIZE = 35
+
+# TODO(garretrieger): populate with some real network models.
+BROADBAND = simulation.NetworkModel(
+    "broadband",
+    rtt=20,  # 40 ms
+    bandwidth_up=1250,  # 10 mbps
+    bandwidth_down=6250)  # 50 mbps
+
+DIALUP = simulation.NetworkModel(
+    "dialup",
+    rtt=200,  # 200 ms
+    bandwidth_up=7,  # 56 kbps
+    bandwidth_down=7)  # 56 kbps

--- a/analysis/pfe_methods/BUILD
+++ b/analysis/pfe_methods/BUILD
@@ -11,6 +11,7 @@ py_library(
     ],
     deps = [
         "//analysis:common",
+        "//analysis:simulation",
         "//analysis/pfe_methods/unicode_range_data:slicing_strategy_loader",
         "//woff2_py",
     ],

--- a/analysis/pfe_methods/unicode_range_pfe_method.py
+++ b/analysis/pfe_methods/unicode_range_pfe_method.py
@@ -12,6 +12,9 @@ These definitions are based on what Google Fonts uses for their production
 font serving.
 """
 
+import os
+
+from analysis import network_models
 from analysis import request_graph
 from analysis.pfe_methods import subset_sizer
 from analysis.pfe_methods.unicode_range_data import slicing_strategy_loader
@@ -79,8 +82,9 @@ class UnicodeRangePfeSession:
     # Unicode range requests can happen in parallel, so there's
     # no deps between individual requests.
     requests = {
-        # TODO(garretrieger): account for HTTP request size and response overhead.
-        request_graph.Request(0, size)
+        request_graph.Request(
+            network_models.ESTIMATED_HTTP_REQUEST_HEADER_SIZE,
+            network_models.ESTIMATED_HTTP_RESPONSE_HEADER_SIZE + size)
         for key, size in subset_sizes.items()
         if key not in self.already_loaded_subsets
     }

--- a/analysis/pfe_methods/unicode_range_pfe_method_test.py
+++ b/analysis/pfe_methods/unicode_range_pfe_method_test.py
@@ -36,7 +36,7 @@ class UnicodeRangePfeMethodTest(unittest.TestCase):
     self.assertEqual(len(graphs), 1)
     self.assertTrue(
         request_graph.graph_has_independent_requests(graphs[0], [
-            (0, 1000),
+            (35, 1035),
         ]))
 
   def test_single_font_multiple_subsets(self):
@@ -46,9 +46,9 @@ class UnicodeRangePfeMethodTest(unittest.TestCase):
     self.assertEqual(len(graphs), 1)
     self.assertTrue(
         request_graph.graph_has_independent_requests(graphs[0], [
-            (0, 1000),
-            (0, 1000),
-            (0, 1000),
+            (35, 1035),
+            (35, 1035),
+            (35, 1035),
         ]))
 
   def test_single_font_caches_subsets(self):
@@ -60,13 +60,13 @@ class UnicodeRangePfeMethodTest(unittest.TestCase):
     self.assertEqual(len(graphs), 3)
     self.assertTrue(
         request_graph.graph_has_independent_requests(graphs[0], [
-            (0, 1000),
-            (0, 1000),
+            (35, 1035),
+            (35, 1035),
         ]))
     self.assertTrue(request_graph.graph_has_independent_requests(graphs[1], []))
     self.assertTrue(
         request_graph.graph_has_independent_requests(graphs[2], [
-            (0, 1000),
+            (35, 1035),
         ]))
 
   def test_multiple_fonts(self):
@@ -79,9 +79,9 @@ class UnicodeRangePfeMethodTest(unittest.TestCase):
     self.assertEqual(len(graphs), 1)
     self.assertTrue(
         request_graph.graph_has_independent_requests(graphs[0], [
-            (0, 1000),
-            (0, 1000),
-            (0, 1000),
+            (35, 1035),
+            (35, 1035),
+            (35, 1035),
         ]))
 
   def test_multiple_fonts_caches_subsets(self):
@@ -100,11 +100,11 @@ class UnicodeRangePfeMethodTest(unittest.TestCase):
     self.assertEqual(len(graphs), 3)
     self.assertTrue(
         request_graph.graph_has_independent_requests(graphs[0], [
-            (0, 1000),
+            (35, 1035),
         ]))
     self.assertTrue(
         request_graph.graph_has_independent_requests(graphs[1], [
-            (0, 1000),
+            (35, 1035),
         ]))
     self.assertTrue(request_graph.graph_has_independent_requests(graphs[2], []))
 

--- a/analysis/pfe_methods/whole_font_pfe_method.py
+++ b/analysis/pfe_methods/whole_font_pfe_method.py
@@ -5,6 +5,9 @@ page view. Subsequent views re-use the cached whole font.
 
 This models traditional font hosting.
 """
+import os
+
+from analysis import network_models
 from analysis import request_graph
 from woff2_py import woff2
 
@@ -38,9 +41,12 @@ class WholeFontPfeSession:
       if font_id in self.loaded_fonts or not codepoints:
         continue
 
-      # TODO(garretrieger): account for HTTP overhead in request and response.
       self.loaded_fonts.add(font_id)
-      requests.add(request_graph.Request(0, self.get_font_size(font_id)))
+      requests.add(
+          request_graph.Request(
+              network_models.ESTIMATED_HTTP_REQUEST_HEADER_SIZE,
+              network_models.ESTIMATED_HTTP_RESPONSE_HEADER_SIZE +
+              self.get_font_size(font_id)))
 
     graph = request_graph.RequestGraph(set())
     if requests:

--- a/analysis/pfe_methods/whole_font_pfe_method_test.py
+++ b/analysis/pfe_methods/whole_font_pfe_method_test.py
@@ -26,7 +26,7 @@ class WholeFontPfeMethodTest(unittest.TestCase):
     self.assertEqual(len(graphs), 1)
     self.assertTrue(
         request_graph.graph_has_independent_requests(graphs[0], [
-            (0, ROBOTO_REGULAR_WOFF2_SIZE),
+            (35, 35 + ROBOTO_REGULAR_WOFF2_SIZE),
         ]))
 
   def test_cached_file_load(self):
@@ -41,7 +41,7 @@ class WholeFontPfeMethodTest(unittest.TestCase):
     self.assertEqual(len(graphs), 1)
     self.assertTrue(
         request_graph.graph_has_independent_requests(graphs[0], [
-            (0, ROBOTO_REGULAR_WOFF2_SIZE),
+            (35, 35 + ROBOTO_REGULAR_WOFF2_SIZE),
         ]))
 
   def test_multiple_file_load(self):
@@ -52,11 +52,11 @@ class WholeFontPfeMethodTest(unittest.TestCase):
     self.assertEqual(len(graphs), 2)
     self.assertTrue(
         request_graph.graph_has_independent_requests(graphs[0], [
-            (0, ROBOTO_REGULAR_WOFF2_SIZE),
+            (35, 35 + ROBOTO_REGULAR_WOFF2_SIZE),
         ]))
     self.assertTrue(
         request_graph.graph_has_independent_requests(graphs[1], [
-            (0, ROBOTO_THIN_WOFF2_SIZE),
+            (35, 35 + ROBOTO_THIN_WOFF2_SIZE),
         ]))
 
   def test_parallel_file_loads(self):
@@ -69,8 +69,8 @@ class WholeFontPfeMethodTest(unittest.TestCase):
     self.assertEqual(len(graphs), 1)
     self.assertTrue(
         request_graph.graph_has_independent_requests(graphs[0], [
-            (0, ROBOTO_REGULAR_WOFF2_SIZE),
-            (0, ROBOTO_THIN_WOFF2_SIZE),
+            (35, 35 + ROBOTO_REGULAR_WOFF2_SIZE),
+            (35, 35 + ROBOTO_THIN_WOFF2_SIZE),
         ]))
 
   def test_single_file_loads_only_once(self):
@@ -81,7 +81,7 @@ class WholeFontPfeMethodTest(unittest.TestCase):
     self.assertEqual(len(graphs), 2)
     self.assertTrue(
         request_graph.graph_has_independent_requests(graphs[0], [
-            (0, ROBOTO_REGULAR_WOFF2_SIZE),
+            (35, 35 + ROBOTO_REGULAR_WOFF2_SIZE),
         ]))
     self.assertTrue(request_graph.graph_has_independent_requests(graphs[1], []))
 

--- a/patch_subset/py/BUILD
+++ b/patch_subset/py/BUILD
@@ -26,6 +26,7 @@ py_library(
     ],
     deps = [
         "//analysis:common",
+        "//analysis:simulation",
     ],
 )
 

--- a/patch_subset/py/patch_subset_method.py
+++ b/patch_subset/py/patch_subset_method.py
@@ -18,6 +18,7 @@ from ctypes import cdll
 from ctypes import POINTER
 from ctypes import Structure
 
+from analysis import network_models
 from analysis import request_graph
 
 # Define the C interface
@@ -119,16 +120,18 @@ class FontSession:
 
 
 def to_request_graph(records):
-  """Convert a listof records into a request graph.
+  """Convert a list of records into a request graph.
 
   In this graph each request depends on the previous request.
   """
   result = set()
   last_request = None
   for record in records:
-    request = request_graph.Request(record.request_size,
-                                    record.response_size,
-                                    happens_after=last_request)
+    request = request_graph.Request(
+        network_models.ESTIMATED_HTTP_REQUEST_HEADER_SIZE + record.request_size,
+        network_models.ESTIMATED_HTTP_RESPONSE_HEADER_SIZE +
+        record.response_size,
+        happens_after=last_request)
     last_request = request
     result.add(request)
   return result


### PR DESCRIPTION
When simulating the size of request and responses sent by a PFE method. Add an estimated fixed overhead for the headers.