### PR TITLE
Emulate http content encoding in patch subset simulation.

### DIFF
--- a/patch_subset/BUILD
+++ b/patch_subset/BUILD
@@ -15,13 +15,10 @@ cc_proto_library(
 cc_library(
     name = "server",
     srcs = [
-        "brotli_binary_diff.cc",
         "harfbuzz_subsetter.cc",
         "patch_subset_server_impl.cc",
     ],
     hdrs = [
-        "binary_diff.h",
-        "brotli_binary_diff.h",
         "harfbuzz_subsetter.h",
         "patch_subset_server_impl.h",
         "subsetter.h",
@@ -43,12 +40,14 @@ cc_library(
     name = "client",
     srcs = [
         "brotli_binary_patch.cc",
+        "brotli_request_logger.cc",
         "memory_request_logger.cc",
         "patch_subset_client.cc",
     ],
     hdrs = [
         "binary_patch.h",
         "brotli_binary_patch.h",
+        "brotli_request_logger.h",
         "memory_request_logger.h",
         "null_request_logger.h",
         "patch_subset_client.h",
@@ -70,6 +69,7 @@ cc_library(
 cc_library(
     name = "common",
     srcs = [
+        "brotli_binary_diff.cc",
         "compressed_set.cc",
         "farm_hasher.cc",
         "file_font_provider.cc",
@@ -77,6 +77,8 @@ cc_library(
         "sparse_bit_set.cc",
     ],
     hdrs = [
+        "binary_diff.h",
+        "brotli_binary_diff.h",
         "compressed_set.h",
         "farm_hasher.h",
         "file_font_provider.h",
@@ -94,6 +96,7 @@ cc_library(
     deps = [
         ":patch_subset_cc_proto",
         "//common",
+        "@brotli//:brotlienc",
         "@com_google_absl//absl/strings",
         "@com_google_absl//absl/types:optional",
         "@farmhash",
@@ -106,6 +109,7 @@ cc_test(
     size = "small",
     srcs = [
         "brotli_patching_test.cc",
+        "brotli_request_logger_test.cc",
         "client_server_integration_test.cc",
         "compressed_set_test.cc",
         "fake_subsetter.h",

--- a/patch_subset/brotli_request_logger.cc
+++ b/patch_subset/brotli_request_logger.cc
@@ -1,0 +1,36 @@
+#include "patch_subset/brotli_request_logger.h"
+
+#include <string>
+#include <vector>
+
+#include "patch_subset/brotli_binary_diff.h"
+#include "patch_subset/font_data.h"
+
+namespace patch_subset {
+
+void BrotliRequestLogger::LogRequest(const std::string& request_data,
+                                     const std::string& response_data) {
+  std::string compressed_request_data;
+  OptionallyCompress(request_data, &compressed_request_data);
+  std::string compressed_response_data;
+  OptionallyCompress(response_data, &compressed_response_data);
+
+  memory_request_logger_->LogRequest(compressed_request_data,
+                                     compressed_response_data);
+}
+
+void BrotliRequestLogger::OptionallyCompress(const std::string& data,
+                                             std::string* output_data) {
+  FontData empty;
+  FontData compressed;
+  FontData font_data(data);
+
+  StatusCode result = brotli_diff_->Diff(empty, font_data, &compressed);
+  if (result == StatusCode::kOk && compressed.size() < data.size()) {
+    *output_data = compressed.str();
+  } else {
+    *output_data = data;
+  }
+}
+
+}  // namespace patch_subset

--- a/patch_subset/brotli_request_logger.cc
+++ b/patch_subset/brotli_request_logger.cc
@@ -27,7 +27,7 @@ void BrotliRequestLogger::OptionallyCompress(const std::string& data,
 
   StatusCode result = brotli_diff_->Diff(empty, font_data, &compressed);
   if (result == StatusCode::kOk && compressed.size() < data.size()) {
-    *output_data = compressed.str();
+    output_data->assign(compressed.data(), compressed.size());
   } else {
     *output_data = data;
   }

--- a/patch_subset/brotli_request_logger.cc
+++ b/patch_subset/brotli_request_logger.cc
@@ -11,16 +11,16 @@ namespace patch_subset {
 void BrotliRequestLogger::LogRequest(const std::string& request_data,
                                      const std::string& response_data) {
   std::string compressed_request_data;
-  OptionallyCompress(request_data, &compressed_request_data);
+  CompressIfSmaller(request_data, &compressed_request_data);
   std::string compressed_response_data;
-  OptionallyCompress(response_data, &compressed_response_data);
+  CompressIfSmaller(response_data, &compressed_response_data);
 
   memory_request_logger_->LogRequest(compressed_request_data,
                                      compressed_response_data);
 }
 
-void BrotliRequestLogger::OptionallyCompress(const std::string& data,
-                                             std::string* output_data) {
+void BrotliRequestLogger::CompressIfSmaller(const std::string& data,
+                                            std::string* output_data) {
   FontData empty;
   FontData compressed;
   FontData font_data(data);

--- a/patch_subset/brotli_request_logger.cc
+++ b/patch_subset/brotli_request_logger.cc
@@ -3,34 +3,48 @@
 #include <string>
 #include <vector>
 
+#include "common/status.h"
 #include "patch_subset/brotli_binary_diff.h"
 #include "patch_subset/font_data.h"
 
 namespace patch_subset {
 
-void BrotliRequestLogger::LogRequest(const std::string& request_data,
-                                     const std::string& response_data) {
+StatusCode BrotliRequestLogger::LogRequest(const std::string& request_data,
+                                           const std::string& response_data) {
   std::string compressed_request_data;
-  CompressIfSmaller(request_data, &compressed_request_data);
+  StatusCode result = CompressIfSmaller(request_data, &compressed_request_data);
+  if (result != StatusCode::kOk) {
+    return result;
+  }
+
   std::string compressed_response_data;
   CompressIfSmaller(response_data, &compressed_response_data);
+  if (result != StatusCode::kOk) {
+    return result;
+  }
 
-  memory_request_logger_->LogRequest(compressed_request_data,
-                                     compressed_response_data);
+  return memory_request_logger_->LogRequest(compressed_request_data,
+                                            compressed_response_data);
 }
 
-void BrotliRequestLogger::CompressIfSmaller(const std::string& data,
-                                            std::string* output_data) {
+StatusCode BrotliRequestLogger::CompressIfSmaller(const std::string& data,
+                                                  std::string* output_data) {
   FontData empty;
   FontData compressed;
   FontData font_data(data);
 
   StatusCode result = brotli_diff_->Diff(empty, font_data, &compressed);
-  if (result == StatusCode::kOk && compressed.size() < data.size()) {
+  if (result != StatusCode::kOk) {
+    return result;
+  }
+
+  if (compressed.size() < data.size()) {
     output_data->assign(compressed.data(), compressed.size());
   } else {
     *output_data = data;
   }
+
+  return StatusCode::kOk;
 }
 
 }  // namespace patch_subset

--- a/patch_subset/brotli_request_logger.h
+++ b/patch_subset/brotli_request_logger.h
@@ -5,6 +5,7 @@
 #include <string>
 #include <vector>
 
+#include "common/status.h"
 #include "patch_subset/brotli_binary_diff.h"
 #include "patch_subset/memory_request_logger.h"
 #include "patch_subset/request_logger.h"
@@ -21,11 +22,12 @@ class BrotliRequestLogger : public RequestLogger {
       : memory_request_logger_(memory_request_logger),
         brotli_diff_(new BrotliBinaryDiff()) {}
 
-  void LogRequest(const std::string& request_data,
-                  const std::string& response_data) override;
+  StatusCode LogRequest(const std::string& request_data,
+                        const std::string& response_data) override;
 
  private:
-  void CompressIfSmaller(const std::string& data, std::string* output_data);
+  StatusCode CompressIfSmaller(const std::string& data,
+                               std::string* output_data);
 
   MemoryRequestLogger* memory_request_logger_;
   std::unique_ptr<BrotliBinaryDiff> brotli_diff_;

--- a/patch_subset/brotli_request_logger.h
+++ b/patch_subset/brotli_request_logger.h
@@ -25,7 +25,7 @@ class BrotliRequestLogger : public RequestLogger {
                   const std::string& response_data) override;
 
  private:
-  void OptionallyCompress(const std::string& data, std::string* output_data);
+  void CompressIfSmaller(const std::string& data, std::string* output_data);
 
   MemoryRequestLogger* memory_request_logger_;
   std::unique_ptr<BrotliBinaryDiff> brotli_diff_;

--- a/patch_subset/brotli_request_logger.h
+++ b/patch_subset/brotli_request_logger.h
@@ -1,0 +1,36 @@
+#ifndef PATCH_SUBSET_BROTLI_REQUEST_LOGGER_H_
+#define PATCH_SUBSET_BROTLI_REQUEST_LOGGER_H_
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "patch_subset/brotli_binary_diff.h"
+#include "patch_subset/memory_request_logger.h"
+#include "patch_subset/request_logger.h"
+
+namespace patch_subset {
+
+// Implementation of RequestLogger that saves applies a pass
+// of brotli compression to the request/response data if
+// it results in a smaller size, then logs the compressed
+// size to an inmemory buffer.
+class BrotliRequestLogger : public RequestLogger {
+ public:
+  BrotliRequestLogger(MemoryRequestLogger* memory_request_logger)
+      : memory_request_logger_(memory_request_logger),
+        brotli_diff_(new BrotliBinaryDiff()) {}
+
+  void LogRequest(const std::string& request_data,
+                  const std::string& response_data) override;
+
+ private:
+  void OptionallyCompress(const std::string& data, std::string* output_data);
+
+  MemoryRequestLogger* memory_request_logger_;
+  std::unique_ptr<BrotliBinaryDiff> brotli_diff_;
+};
+
+}  // namespace patch_subset
+
+#endif  // PATCH_SUBSET_BROTLI_REQUEST_LOGGER_H_

--- a/patch_subset/brotli_request_logger_test.cc
+++ b/patch_subset/brotli_request_logger_test.cc
@@ -35,7 +35,9 @@ TEST_F(BrotliRequestLoggerTest, Compresses) {
   const MemoryRequestLogger::Record& record =
       memory_request_logger_->Records()[0];
   EXPECT_LT(record.request_size, request_data.size());
+  EXPECT_GT(record.request_size, 0);
   EXPECT_LT(record.response_size, response_data.size());
+  EXPECT_GT(record.response_size, 0);
 }
 
 TEST_F(BrotliRequestLoggerTest, DoesntCompress) {

--- a/patch_subset/brotli_request_logger_test.cc
+++ b/patch_subset/brotli_request_logger_test.cc
@@ -1,0 +1,54 @@
+#include "patch_subset/brotli_request_logger.h"
+
+#include "gtest/gtest.h"
+
+namespace patch_subset {
+
+class BrotliRequestLoggerTest : public ::testing::Test {
+ protected:
+  BrotliRequestLoggerTest()
+      : memory_request_logger_(new MemoryRequestLogger()),
+        request_logger_(new BrotliRequestLogger(memory_request_logger_.get())) {
+  }
+
+  ~BrotliRequestLoggerTest() override {}
+
+  void SetUp() override {}
+
+  std::unique_ptr<MemoryRequestLogger> memory_request_logger_;
+  std::unique_ptr<BrotliRequestLogger> request_logger_;
+};
+
+TEST_F(BrotliRequestLoggerTest, Compresses) {
+  std::string request_data =
+      "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+      "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+      "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+  std::string response_data =
+      "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+      "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+      "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+
+  request_logger_->LogRequest(request_data, response_data);
+
+  EXPECT_EQ(memory_request_logger_->Records().size(), 1);
+  const MemoryRequestLogger::Record& record =
+      memory_request_logger_->Records()[0];
+  EXPECT_LT(record.request_size, request_data.size());
+  EXPECT_LT(record.response_size, response_data.size());
+}
+
+TEST_F(BrotliRequestLoggerTest, DoesntCompress) {
+  std::string request_data = "abcdefghijk";
+  std::string response_data = "abcdefghijk";
+
+  request_logger_->LogRequest(request_data, response_data);
+
+  EXPECT_EQ(memory_request_logger_->Records().size(), 1);
+  const MemoryRequestLogger::Record& record =
+      memory_request_logger_->Records()[0];
+  EXPECT_EQ(record.request_size, request_data.size());
+  EXPECT_EQ(record.response_size, response_data.size());
+}
+
+}  // namespace patch_subset

--- a/patch_subset/brotli_request_logger_test.cc
+++ b/patch_subset/brotli_request_logger_test.cc
@@ -29,7 +29,8 @@ TEST_F(BrotliRequestLoggerTest, Compresses) {
       "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
       "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
 
-  request_logger_->LogRequest(request_data, response_data);
+  EXPECT_EQ(request_logger_->LogRequest(request_data, response_data),
+            StatusCode::kOk);
 
   EXPECT_EQ(memory_request_logger_->Records().size(), 1);
   const MemoryRequestLogger::Record& record =
@@ -44,7 +45,8 @@ TEST_F(BrotliRequestLoggerTest, DoesntCompress) {
   std::string request_data = "abcdefghijk";
   std::string response_data = "abcdefghijk";
 
-  request_logger_->LogRequest(request_data, response_data);
+  EXPECT_EQ(request_logger_->LogRequest(request_data, response_data),
+            StatusCode::kOk);
 
   EXPECT_EQ(memory_request_logger_->Records().size(), 1);
   const MemoryRequestLogger::Record& record =

--- a/patch_subset/memory_request_logger.cc
+++ b/patch_subset/memory_request_logger.cc
@@ -3,14 +3,17 @@
 #include <string>
 #include <vector>
 
+#include "common/status.h"
+
 namespace patch_subset {
 
-void MemoryRequestLogger::LogRequest(const std::string& request_data,
-                                     const std::string& response_data) {
+StatusCode MemoryRequestLogger::LogRequest(const std::string& request_data,
+                                           const std::string& response_data) {
   MemoryRequestLogger::Record record;
   record.request_size = request_data.size();
   record.response_size = response_data.size();
   records_.push_back(record);
+  return StatusCode::kOk;
 }
 
 const std::vector<MemoryRequestLogger::Record>& MemoryRequestLogger::Records()

--- a/patch_subset/memory_request_logger.h
+++ b/patch_subset/memory_request_logger.h
@@ -4,6 +4,7 @@
 #include <string>
 #include <vector>
 
+#include "common/status.h"
 #include "patch_subset/request_logger.h"
 
 namespace patch_subset {
@@ -17,8 +18,8 @@ class MemoryRequestLogger : public RequestLogger {
     uint32_t response_size;
   };
 
-  void LogRequest(const std::string& request_data,
-                  const std::string& response_data) override;
+  StatusCode LogRequest(const std::string& request_data,
+                        const std::string& response_data) override;
 
   const std::vector<Record>& Records() const;
 

--- a/patch_subset/null_request_logger.h
+++ b/patch_subset/null_request_logger.h
@@ -1,6 +1,7 @@
 #ifndef PATCH_SUBSET_NULL_REQUEST_LOGGER_H_
 #define PATCH_SUBSET_NULL_REQUEST_LOGGER_H_
 
+#include "common/status.h"
 #include "patch_subset/request_logger.h"
 
 namespace patch_subset {
@@ -8,9 +9,10 @@ namespace patch_subset {
 // Implementation of RequestLogger that does nothing.
 class NullRequestLogger : public RequestLogger {
  public:
-  void LogRequest(const std::string& request_data,
-                  const std::string& response_data) override {
+  StatusCode LogRequest(const std::string& request_data,
+                        const std::string& response_data) override {
     // Do nothing.
+    return StatusCode::kOk;
   }
 };
 

--- a/patch_subset/py/patch_subset_session.cc
+++ b/patch_subset/py/patch_subset_session.cc
@@ -9,6 +9,7 @@
 #include "hb.h"
 #include "patch_subset/brotli_binary_diff.h"
 #include "patch_subset/brotli_binary_patch.h"
+#include "patch_subset/brotli_request_logger.h"
 #include "patch_subset/farm_hasher.h"
 #include "patch_subset/file_font_provider.h"
 #include "patch_subset/font_provider.h"
@@ -22,6 +23,7 @@ using ::patch_subset::BinaryDiff;
 using ::patch_subset::BinaryPatch;
 using ::patch_subset::BrotliBinaryDiff;
 using ::patch_subset::BrotliBinaryPatch;
+using ::patch_subset::BrotliRequestLogger;
 using ::patch_subset::ClientState;
 using ::patch_subset::FarmHasher;
 using ::patch_subset::FileFontProvider;
@@ -41,11 +43,12 @@ class PatchSubsetSession {
       : font_provider_(new FileFontProvider(font_directory)),
         binary_diff_(new BrotliBinaryDiff()),
         binary_patch_(new BrotliBinaryPatch()),
+        brotli_request_logger_(&request_logger_),
         server_(std::unique_ptr<FontProvider>(font_provider_),
                 std::unique_ptr<Subsetter>(new HarfbuzzSubsetter()),
                 std::unique_ptr<BinaryDiff>(binary_diff_),
                 std::unique_ptr<Hasher>(new FarmHasher())),
-        client_(&server_, &request_logger_,
+        client_(&server_, &brotli_request_logger_,
                 std::unique_ptr<BinaryPatch>(binary_patch_),
                 std::unique_ptr<Hasher>(new FarmHasher())) {
     client_state_.set_font_id(font_id);
@@ -67,6 +70,7 @@ class PatchSubsetSession {
   BinaryDiff* binary_diff_;
   BinaryPatch* binary_patch_;
   MemoryRequestLogger request_logger_;
+  BrotliRequestLogger brotli_request_logger_;
   PatchSubsetServerImpl server_;
   PatchSubsetClient client_;
   ClientState client_state_;

--- a/patch_subset/request_logger.h
+++ b/patch_subset/request_logger.h
@@ -3,6 +3,8 @@
 
 #include <string>
 
+#include "common/status.h"
+
 namespace patch_subset {
 
 // Client for interacting with a PatchSubsetServer. Allows
@@ -12,8 +14,8 @@ class RequestLogger {
  public:
   virtual ~RequestLogger() = default;
 
-  virtual void LogRequest(const std::string& request_data,
-                          const std::string& response_data) = 0;
+  virtual StatusCode LogRequest(const std::string& request_data,
+                                const std::string& response_data) = 0;
 };
 
 }  // namespace patch_subset


### PR DESCRIPTION
In the patch subset PFE simulation optionally apply brotli compression if it results in smaller request/response. This emulates applying content-encoding: br for the HTTP request/responses.