### PR TITLE
Fix negative response sizes in the optimal method. 

### DIFF
--- a/analysis/pfe_methods/optimal_pfe_method.py
+++ b/analysis/pfe_methods/optimal_pfe_method.py
@@ -58,7 +58,7 @@ class OptimalPfeSession:
     delta = size - self.subset_size_by_font.get(font_id, 0)
     self.subset_size_by_font[font_id] = size
 
-    if delta:
+    if delta > 0:
       return {request_graph.Request(0, delta)}
 
     return set()


### PR DESCRIPTION
It's possible to have a subsequent subset end up smaller than the one before. Check for this case and don't generate a request with a negative size.