### PR TITLE
Add an optional codepoint remapping to rebase responses.

### DIFF
--- a/patch_subset/BUILD
+++ b/patch_subset/BUILD
@@ -15,12 +15,14 @@ cc_proto_library(
 cc_library(
     name = "server",
     srcs = [
+        "codepoint_mapping_checksum.cc",
         "harfbuzz_subsetter.cc",
         "patch_subset_server_impl.cc",
         "simple_codepoint_mapper.cc",
     ],
     hdrs = [
         "codepoint_mapper.h",
+        "codepoint_mapping_checksum.h",
         "harfbuzz_subsetter.h",
         "patch_subset_server_impl.h",
         "simple_codepoint_mapper.h",
@@ -114,6 +116,7 @@ cc_test(
         "brotli_patching_test.cc",
         "brotli_request_logger_test.cc",
         "client_server_integration_test.cc",
+        "codepoint_mapping_checksum_test.cc",
         "compressed_set_test.cc",
         "fake_subsetter.h",
         "file_font_provider_test.cc",

--- a/patch_subset/BUILD
+++ b/patch_subset/BUILD
@@ -17,10 +17,13 @@ cc_library(
     srcs = [
         "harfbuzz_subsetter.cc",
         "patch_subset_server_impl.cc",
+        "simple_codepoint_mapper.cc",
     ],
     hdrs = [
+        "codepoint_mapper.h",
         "harfbuzz_subsetter.h",
         "patch_subset_server_impl.h",
+        "simple_codepoint_mapper.h",
         "subsetter.h",
     ],
     visibility = [
@@ -123,6 +126,7 @@ cc_test(
         "patch_subset_client_test.cc",
         "patch_subset_server_impl_test.cc",
         "server_integration_test.cc",
+        "simple_codepoint_mapper_test.cc",
         "sparse_bit_set_test.cc",
     ],
     data = [

--- a/patch_subset/BUILD
+++ b/patch_subset/BUILD
@@ -15,7 +15,7 @@ cc_proto_library(
 cc_library(
     name = "server",
     srcs = [
-        "codepoint_mapping_checksum.cc",
+        "codepoint_mapping_checksum_impl.cc",
         "harfbuzz_subsetter.cc",
         "patch_subset_server_impl.cc",
         "simple_codepoint_mapper.cc",
@@ -23,6 +23,7 @@ cc_library(
     hdrs = [
         "codepoint_mapper.h",
         "codepoint_mapping_checksum.h",
+        "codepoint_mapping_checksum_impl.h",
         "harfbuzz_subsetter.h",
         "patch_subset_server_impl.h",
         "simple_codepoint_mapper.h",
@@ -116,13 +117,14 @@ cc_test(
         "brotli_patching_test.cc",
         "brotli_request_logger_test.cc",
         "client_server_integration_test.cc",
-        "codepoint_mapping_checksum_test.cc",
+        "codepoint_mapping_checksum_impl_test.cc",
         "compressed_set_test.cc",
         "fake_subsetter.h",
         "file_font_provider_test.cc",
         "harfbuzz_subsetter_test.cc",
         "mock_binary_diff.h",
         "mock_binary_patch.h",
+        "mock_codepoint_mapping_checksum.h",
         "mock_font_provider.h",
         "mock_hasher.h",
         "mock_patch_subset_server.h",

--- a/patch_subset/client_server_integration_test.cc
+++ b/patch_subset/client_server_integration_test.cc
@@ -2,6 +2,7 @@
 #include "patch_subset/brotli_binary_diff.h"
 #include "patch_subset/brotli_binary_patch.h"
 #include "patch_subset/codepoint_mapper.h"
+#include "patch_subset/codepoint_mapping_checksum.h"
 #include "patch_subset/compressed_set.h"
 #include "patch_subset/farm_hasher.h"
 #include "patch_subset/file_font_provider.h"
@@ -26,7 +27,8 @@ class PatchSubsetClientServerIntegrationTest : public ::testing::Test {
                 std::unique_ptr<Subsetter>(new HarfbuzzSubsetter()),
                 std::unique_ptr<BinaryDiff>(binary_diff_),
                 std::unique_ptr<Hasher>(new FarmHasher()),
-                std::unique_ptr<CodepointMapper>(nullptr)),
+                std::unique_ptr<CodepointMapper>(nullptr),
+                std::unique_ptr<CodepointMappingChecksum>(nullptr)),
         client_(&server_, &request_logger_,
                 std::unique_ptr<BinaryPatch>(binary_patch_),
                 std::unique_ptr<Hasher>(new FarmHasher())) {

--- a/patch_subset/client_server_integration_test.cc
+++ b/patch_subset/client_server_integration_test.cc
@@ -1,6 +1,7 @@
 #include "gtest/gtest.h"
 #include "patch_subset/brotli_binary_diff.h"
 #include "patch_subset/brotli_binary_patch.h"
+#include "patch_subset/codepoint_mapper.h"
 #include "patch_subset/compressed_set.h"
 #include "patch_subset/farm_hasher.h"
 #include "patch_subset/file_font_provider.h"
@@ -24,7 +25,8 @@ class PatchSubsetClientServerIntegrationTest : public ::testing::Test {
         server_(std::unique_ptr<FontProvider>(font_provider_),
                 std::unique_ptr<Subsetter>(new HarfbuzzSubsetter()),
                 std::unique_ptr<BinaryDiff>(binary_diff_),
-                std::unique_ptr<Hasher>(new FarmHasher())),
+                std::unique_ptr<Hasher>(new FarmHasher()),
+                std::unique_ptr<CodepointMapper>(nullptr)),
         client_(&server_, &request_logger_,
                 std::unique_ptr<BinaryPatch>(binary_patch_),
                 std::unique_ptr<Hasher>(new FarmHasher())) {

--- a/patch_subset/codepoint_mapper.h
+++ b/patch_subset/codepoint_mapper.h
@@ -1,0 +1,26 @@
+#ifndef PATCH_SUBSET_CODEPOINT_MAPPER_H_
+#define PATCH_SUBSET_CODEPOINT_MAPPER_H_
+
+#include <vector>
+
+#include "hb.h"
+
+namespace patch_subset {
+
+// Interface to a codepoint mapper.
+class CodepointMapper {
+ public:
+  virtual ~CodepointMapper() = default;
+
+  // Computes a mapping for the provided codepoints. The mapping
+  // is written into the mapping vector.
+  //
+  // To interpret the mapping vector: codepoint value 'mapping[i]'
+  // is mapped to value 'i'.
+  virtual void ComputeMapping(const hb_set_t& codepoints,
+                              std::vector<hb_codepoint_t>* mapping) const = 0;
+};
+
+}  // namespace patch_subset
+
+#endif  // PATCH_SUBSET_CODEPOINT_MAPPER_H_

--- a/patch_subset/codepoint_mapping_checksum.cc
+++ b/patch_subset/codepoint_mapping_checksum.cc
@@ -1,0 +1,40 @@
+#include "patch_subset/codepoint_mapping_checksum.h"
+
+#include <vector>
+
+#include "absl/strings/string_view.h"
+
+namespace patch_subset {
+
+struct LittleEndianInt {
+ public:
+  LittleEndianInt& operator=(int32_t value) {
+    data[0] = (value)&0xFF;
+    data[1] = (value >> 8) & 0xFF;
+    data[2] = (value >> 16) & 0xFF;
+    data[3] = (value >> 24) & 0xFF;
+    return *this;
+  }
+
+ private:
+  uint8_t data[4];
+};
+
+uint64_t CodepointMappingChecksum::Checksum(
+    const CodepointRemappingProto& response) {
+  int num_deltas = response.codepoint_ordering().deltas_size();
+
+  std::vector<LittleEndianInt> data(num_deltas + 1);
+  data[0] = num_deltas;
+  for (int i = 0; i < num_deltas; i++) {
+    data[i + 1] = response.codepoint_ordering().deltas(i);
+  }
+
+  // TODO(garretrieger): implement checksumming of the grouping strategy.
+
+  return this->hasher_->Checksum(
+      absl::string_view(reinterpret_cast<char*>(data.data()),
+                        data.size() * sizeof(LittleEndianInt)));
+}
+
+}  // namespace patch_subset

--- a/patch_subset/codepoint_mapping_checksum.h
+++ b/patch_subset/codepoint_mapping_checksum.h
@@ -9,17 +9,12 @@ namespace patch_subset {
 // Interface to a codepoint mapper.
 class CodepointMappingChecksum {
  public:
-  // Does not take ownership of hasher. hasher must live longer than this
-  // object.
-  CodepointMappingChecksum(Hasher* hasher) : hasher_(hasher) {}
+  virtual ~CodepointMappingChecksum() = default;
 
   // Compute a checksum for the provided CodepointRemappingProto. This
   // checksum function must be stable. It should always return the same
   // value for the same input proto.
-  uint64_t Checksum(const CodepointRemappingProto& response);
-
- private:
-  const Hasher* hasher_;
+  virtual uint64_t Checksum(const CodepointRemappingProto& response) const = 0;
 };
 
 }  // namespace patch_subset

--- a/patch_subset/codepoint_mapping_checksum.h
+++ b/patch_subset/codepoint_mapping_checksum.h
@@ -1,0 +1,27 @@
+#ifndef PATCH_SUBSET_CODEPOINT_MAPPING_CHECKSUM_H_
+#define PATCH_SUBSET_CODEPOINT_MAPPING_CHECKSUM_H_
+
+#include "patch_subset/hasher.h"
+#include "patch_subset/patch_subset.pb.h"
+
+namespace patch_subset {
+
+// Interface to a codepoint mapper.
+class CodepointMappingChecksum {
+ public:
+  // Does not take ownership of hasher. hasher must live longer than this
+  // object.
+  CodepointMappingChecksum(Hasher* hasher) : hasher_(hasher) {}
+
+  // Compute a checksum for the provided CodepointRemappingProto. This
+  // checksum function must be stable. It should always return the same
+  // value for the same input proto.
+  uint64_t Checksum(const CodepointRemappingProto& response);
+
+ private:
+  const Hasher* hasher_;
+};
+
+}  // namespace patch_subset
+
+#endif  // PATCH_SUBSET_CODEPOINT_MAPPING_CHECKSUM_H_

--- a/patch_subset/codepoint_mapping_checksum_impl.cc
+++ b/patch_subset/codepoint_mapping_checksum_impl.cc
@@ -1,4 +1,4 @@
-#include "patch_subset/codepoint_mapping_checksum.h"
+#include "patch_subset/codepoint_mapping_checksum_impl.h"
 
 #include <vector>
 
@@ -20,8 +20,8 @@ struct LittleEndianInt {
   uint8_t data[4];
 };
 
-uint64_t CodepointMappingChecksum::Checksum(
-    const CodepointRemappingProto& response) {
+uint64_t CodepointMappingChecksumImpl::Checksum(
+    const CodepointRemappingProto& response) const {
   int num_deltas = response.codepoint_ordering().deltas_size();
 
   std::vector<LittleEndianInt> data(num_deltas + 1);

--- a/patch_subset/codepoint_mapping_checksum_impl.h
+++ b/patch_subset/codepoint_mapping_checksum_impl.h
@@ -1,0 +1,25 @@
+#ifndef PATCH_SUBSET_CODEPOINT_MAPPING_CHECKSUM_IMPL_H_
+#define PATCH_SUBSET_CODEPOINT_MAPPING_CHECKSUM_IMPL_H_
+
+#include "patch_subset/codepoint_mapping_checksum.h"
+#include "patch_subset/hasher.h"
+#include "patch_subset/patch_subset.pb.h"
+
+namespace patch_subset {
+
+// Interface to a codepoint mapper.
+class CodepointMappingChecksumImpl : public CodepointMappingChecksum {
+ public:
+  // Does not take ownership of hasher. hasher must live longer than this
+  // object.
+  CodepointMappingChecksumImpl(Hasher* hasher) : hasher_(hasher) {}
+
+  uint64_t Checksum(const CodepointRemappingProto& response) const override;
+
+ private:
+  const Hasher* hasher_;
+};
+
+}  // namespace patch_subset
+
+#endif  // PATCH_SUBSET_CODEPOINT_MAPPING_CHECKSUM_IMPL_H_

--- a/patch_subset/codepoint_mapping_checksum_impl_test.cc
+++ b/patch_subset/codepoint_mapping_checksum_impl_test.cc
@@ -1,20 +1,20 @@
-#include "patch_subset/codepoint_mapping_checksum.h"
+#include "patch_subset/codepoint_mapping_checksum_impl.h"
 
 #include "gtest/gtest.h"
 #include "patch_subset/farm_hasher.h"
 
 namespace patch_subset {
 
-class CodepointMappingChecksumTest : public ::testing::Test {
+class CodepointMappingChecksumImplTest : public ::testing::Test {
  protected:
-  CodepointMappingChecksumTest()
+  CodepointMappingChecksumImplTest()
       : hasher_(new FarmHasher()), codepoint_checksum_(hasher_.get()) {}
 
   std::unique_ptr<Hasher> hasher_;
-  CodepointMappingChecksum codepoint_checksum_;
+  CodepointMappingChecksumImpl codepoint_checksum_;
 };
 
-TEST_F(CodepointMappingChecksumTest, ChecksumOnlyDeltas) {
+TEST_F(CodepointMappingChecksumImplTest, ChecksumOnlyDeltas) {
   // The checksum should be stable across architectures and time, so test
   // against the exact checksum values, which should not change in the future.
   CodepointRemappingProto proto;

--- a/patch_subset/codepoint_mapping_checksum_test.cc
+++ b/patch_subset/codepoint_mapping_checksum_test.cc
@@ -1,0 +1,42 @@
+#include "patch_subset/codepoint_mapping_checksum.h"
+
+#include "gtest/gtest.h"
+#include "patch_subset/farm_hasher.h"
+
+namespace patch_subset {
+
+class CodepointMappingChecksumTest : public ::testing::Test {
+ protected:
+  CodepointMappingChecksumTest()
+      : hasher_(new FarmHasher()), codepoint_checksum_(hasher_.get()) {}
+
+  std::unique_ptr<Hasher> hasher_;
+  CodepointMappingChecksum codepoint_checksum_;
+};
+
+TEST_F(CodepointMappingChecksumTest, ChecksumOnlyDeltas) {
+  // The checksum should be stable across architectures and time, so test
+  // against the exact checksum values, which should not change in the future.
+  CodepointRemappingProto proto;
+  CompressedListProto* codepoint_ordering = proto.mutable_codepoint_ordering();
+
+  EXPECT_EQ(codepoint_checksum_.Checksum(proto), 10786723806386174706);
+
+  codepoint_ordering->add_deltas(1);
+  codepoint_ordering->add_deltas(5);
+  codepoint_ordering->add_deltas(7);
+  EXPECT_EQ(codepoint_checksum_.Checksum(proto), 3761381749415832926);
+
+  // Adding a delta should change the checksum.
+  codepoint_ordering->add_deltas(9);
+  EXPECT_EQ(codepoint_checksum_.Checksum(proto), 17013761565217376327);
+
+  // Check that the ordering of the deltas matters.
+  codepoint_ordering->clear_deltas();
+  codepoint_ordering->add_deltas(7);
+  codepoint_ordering->add_deltas(5);
+  codepoint_ordering->add_deltas(1);
+  EXPECT_EQ(codepoint_checksum_.Checksum(proto), 3695224139272583709);
+}
+
+}  // namespace patch_subset

--- a/patch_subset/fake_subsetter.h
+++ b/patch_subset/fake_subsetter.h
@@ -36,6 +36,13 @@ class FakeSubsetter : public Subsetter {
     subset->copy(result.c_str(), result.size());
     return StatusCode::kOk;
   }
+
+  void CodepointsInFont(const FontData& font,
+                        hb_set_t* codepoints) const override {
+    hb_set_add(codepoints, 1);
+    hb_set_add(codepoints, 2);
+    hb_set_add(codepoints, 3);
+  }
 };
 
 }  // namespace patch_subset

--- a/patch_subset/harfbuzz_subsetter.cc
+++ b/patch_subset/harfbuzz_subsetter.cc
@@ -55,4 +55,14 @@ StatusCode HarfbuzzSubsetter::Subset(const FontData& font,
   return StatusCode::kOk;
 }
 
+void HarfbuzzSubsetter::CodepointsInFont(const FontData& font,
+                                         hb_set_t* codepoints) const {
+  hb_blob_t* blob = font.reference_blob();
+  hb_face_t* face = hb_face_create(blob, 0);
+  hb_blob_destroy(blob);
+
+  hb_face_collect_unicodes(face, codepoints);
+  hb_face_destroy(face);
+}
+
 }  // namespace patch_subset

--- a/patch_subset/harfbuzz_subsetter.h
+++ b/patch_subset/harfbuzz_subsetter.h
@@ -16,6 +16,9 @@ class HarfbuzzSubsetter : public Subsetter {
   StatusCode Subset(const FontData& font, const hb_set_t& codepoints,
                     FontData* subset /* OUT */) const override;
 
+  void CodepointsInFont(const FontData& font,
+                        hb_set_t* codepoints) const override;
+
  private:
 };
 

--- a/patch_subset/harfbuzz_subsetter_test.cc
+++ b/patch_subset/harfbuzz_subsetter_test.cc
@@ -61,4 +61,33 @@ TEST_F(HarfbuzzSubsetterTest, SubsetEmpty) {
   hb_blob_destroy(subset_blob);
 }
 
+TEST_F(HarfbuzzSubsetterTest, CodepointsInFont) {
+  FontData font_data_1, font_data_2;
+  EXPECT_EQ(font_provider_->GetFont("Roboto-Regular.Meows.ttf", &font_data_1),
+            StatusCode::kOk);
+  EXPECT_EQ(font_provider_->GetFont("Roboto-Regular.Awesome.ttf", &font_data_2),
+            StatusCode::kOk);
+
+  hb_set_unique_ptr expected = make_hb_set(5, 0x4D, 0x65, 0x6F, 0x77, 0x73);
+
+  hb_set_unique_ptr result = make_hb_set();
+  subsetter_->CodepointsInFont(font_data_1, result.get());
+  EXPECT_TRUE(hb_set_is_equal(result.get(), expected.get()));
+
+  expected = make_hb_set(7, 0x41, 0x4D, 0x65, 0x6D, 0x6F, 0x77, 0x73);
+  result = make_hb_set();
+  subsetter_->CodepointsInFont(font_data_2, result.get());
+  EXPECT_TRUE(hb_set_is_equal(result.get(), expected.get()));
+}
+
+TEST_F(HarfbuzzSubsetterTest, CodepointsInFont_BadFont) {
+  FontData font_data("not a font");
+
+  hb_set_unique_ptr expected = make_hb_set();
+  hb_set_unique_ptr result = make_hb_set();
+  subsetter_->CodepointsInFont(font_data, result.get());
+
+  EXPECT_TRUE(hb_set_is_equal(expected.get(), result.get()));
+}
+
 }  // namespace patch_subset

--- a/patch_subset/mock_codepoint_mapping_checksum.h
+++ b/patch_subset/mock_codepoint_mapping_checksum.h
@@ -1,0 +1,20 @@
+#ifndef PATCH_SUBSET_MOCK_CODEPOINT_MAPPING_CHECKSUM_H_
+#define PATCH_SUBSET_MOCK_CODEPOINT_MAPPING_CHECKSUM_H_
+
+#include <string>
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+#include "patch_subset/codepoint_mapping_checksum.h"
+
+namespace patch_subset {
+
+class MockCodepointMappingChecksum : public CodepointMappingChecksum {
+ public:
+  MOCK_METHOD(uint64_t, Checksum, (const CodepointRemappingProto& proto),
+              (const override));
+};
+
+}  // namespace patch_subset
+
+#endif  // PATCH_SUBSET_MOCK_CODEPOINT_MAPPING_CHECKSUM_H_

--- a/patch_subset/patch_subset_server_impl.cc
+++ b/patch_subset/patch_subset_server_impl.cc
@@ -17,6 +17,12 @@ namespace patch_subset {
 StatusCode PatchSubsetServerImpl::Handle(const std::string& font_id,
                                          const PatchRequestProto& request,
                                          PatchResponseProto* response) {
+  // TODO(garretrieger): check fingerprint on codepoint remapping
+  //                     (if this is a patch request).
+  // TODO(garretrieger): apply codepoint remapping when decoding code point
+  // sets.
+  //                     (if this is a patch request).
+
   hb_set_unique_ptr codepoints_have = make_hb_set();
   CompressedSet::Decode(request.codepoints_have(), codepoints_have.get());
 
@@ -65,7 +71,6 @@ StatusCode PatchSubsetServerImpl::Handle(const std::string& font_id,
     return result;
   }
   // TODO(garretrieger): rename the proto package.
-  // TODO(garretrieger): codepoint index computation
   // TODO(garretrieger): check which diffs the client supports.
   // TODO(garretrieger): handle exceptional cases (see design doc).
 
@@ -79,6 +84,9 @@ StatusCode PatchSubsetServerImpl::Handle(const std::string& font_id,
   patch_proto->set_patch(patch.data(), patch.size());
 
   AddFingerprints(font_data, client_target_subset, response);
+
+  // TODO(garretrieger): if this is a REBASE request then compute and send a
+  //                     codepoint remapping.
 
   return StatusCode::kOk;
 }

--- a/patch_subset/patch_subset_server_impl.cc
+++ b/patch_subset/patch_subset_server_impl.cc
@@ -105,8 +105,9 @@ void PatchSubsetServerImpl::AddCodepointRemapping(
     previous_cp = cp;
   }
 
-  // TODO(garretrieger): compute and set the fingerprint.
   // TODO(garretrieger): add a grouping strategy if it's needed.
+
+  response->set_fingerprint(codepoint_mapping_checksum_->Checksum(*response));
 }
 
 StatusCode PatchSubsetServerImpl::ComputeSubsets(

--- a/patch_subset/patch_subset_server_impl.h
+++ b/patch_subset/patch_subset_server_impl.h
@@ -6,6 +6,7 @@
 #include "common/status.h"
 #include "hb.h"
 #include "patch_subset/binary_diff.h"
+#include "patch_subset/codepoint_mapper.h"
 #include "patch_subset/font_provider.h"
 #include "patch_subset/hasher.h"
 #include "patch_subset/patch_subset.pb.h"
@@ -20,13 +21,15 @@ class PatchSubsetServerImpl : public PatchSubsetServer {
   PatchSubsetServerImpl(std::unique_ptr<FontProvider> font_provider,
                         std::unique_ptr<Subsetter> subsetter,
                         std::unique_ptr<BinaryDiff> binary_diff,
-                        std::unique_ptr<Hasher> hasher)
+                        std::unique_ptr<Hasher> hasher,
+                        std::unique_ptr<CodepointMapper> codepoint_mapper)
       // TODO(garretrieger): take a boolean that specifies if codepoint
       //                     remapping should be used.
       : font_provider_(std::move(font_provider)),
         subsetter_(std::move(subsetter)),
         binary_diff_(std::move(binary_diff)),
-        hasher_(std::move(hasher)) {}
+        hasher_(std::move(hasher)),
+        codepoint_mapper_(std::move(codepoint_mapper)) {}
 
   // Handle a patch request from a client. Writes the resulting response
   // into response.
@@ -35,6 +38,9 @@ class PatchSubsetServerImpl : public PatchSubsetServer {
                     PatchResponseProto* response /* OUT */) override;
 
  private:
+  void AddCodepointRemapping(const FontData& font_data,
+                             CodepointRemappingProto* response);
+
   StatusCode ComputeSubsets(const std::string& font_id,
                             const FontData& font_data,
                             const hb_set_t& codepoints_have,
@@ -54,6 +60,7 @@ class PatchSubsetServerImpl : public PatchSubsetServer {
   std::unique_ptr<Subsetter> subsetter_;
   std::unique_ptr<BinaryDiff> binary_diff_;
   std::unique_ptr<Hasher> hasher_;
+  std::unique_ptr<CodepointMapper> codepoint_mapper_;
 };
 
 }  // namespace patch_subset

--- a/patch_subset/patch_subset_server_impl.h
+++ b/patch_subset/patch_subset_server_impl.h
@@ -7,6 +7,7 @@
 #include "hb.h"
 #include "patch_subset/binary_diff.h"
 #include "patch_subset/codepoint_mapper.h"
+#include "patch_subset/codepoint_mapping_checksum.h"
 #include "patch_subset/font_provider.h"
 #include "patch_subset/hasher.h"
 #include "patch_subset/patch_subset.pb.h"
@@ -18,18 +19,18 @@ namespace patch_subset {
 class PatchSubsetServerImpl : public PatchSubsetServer {
  public:
   // Takes ownership of font_provider, subsetter, and binary_diff.
-  PatchSubsetServerImpl(std::unique_ptr<FontProvider> font_provider,
-                        std::unique_ptr<Subsetter> subsetter,
-                        std::unique_ptr<BinaryDiff> binary_diff,
-                        std::unique_ptr<Hasher> hasher,
-                        std::unique_ptr<CodepointMapper> codepoint_mapper)
-      // TODO(garretrieger): take a boolean that specifies if codepoint
-      //                     remapping should be used.
+  PatchSubsetServerImpl(
+      std::unique_ptr<FontProvider> font_provider,
+      std::unique_ptr<Subsetter> subsetter,
+      std::unique_ptr<BinaryDiff> binary_diff, std::unique_ptr<Hasher> hasher,
+      std::unique_ptr<CodepointMapper> codepoint_mapper,
+      std::unique_ptr<CodepointMappingChecksum> codepoint_mapping_checksum)
       : font_provider_(std::move(font_provider)),
         subsetter_(std::move(subsetter)),
         binary_diff_(std::move(binary_diff)),
         hasher_(std::move(hasher)),
-        codepoint_mapper_(std::move(codepoint_mapper)) {}
+        codepoint_mapper_(std::move(codepoint_mapper)),
+        codepoint_mapping_checksum_(std::move(codepoint_mapping_checksum)) {}
 
   // Handle a patch request from a client. Writes the resulting response
   // into response.
@@ -61,6 +62,7 @@ class PatchSubsetServerImpl : public PatchSubsetServer {
   std::unique_ptr<BinaryDiff> binary_diff_;
   std::unique_ptr<Hasher> hasher_;
   std::unique_ptr<CodepointMapper> codepoint_mapper_;
+  std::unique_ptr<CodepointMappingChecksum> codepoint_mapping_checksum_;
 };
 
 }  // namespace patch_subset

--- a/patch_subset/patch_subset_server_impl.h
+++ b/patch_subset/patch_subset_server_impl.h
@@ -21,6 +21,8 @@ class PatchSubsetServerImpl : public PatchSubsetServer {
                         std::unique_ptr<Subsetter> subsetter,
                         std::unique_ptr<BinaryDiff> binary_diff,
                         std::unique_ptr<Hasher> hasher)
+      // TODO(garretrieger): take a boolean that specifies if codepoint
+      //                     remapping should be used.
       : font_provider_(std::move(font_provider)),
         subsetter_(std::move(subsetter)),
         binary_diff_(std::move(binary_diff)),

--- a/patch_subset/patch_subset_server_impl_test.cc
+++ b/patch_subset/patch_subset_server_impl_test.cc
@@ -6,6 +6,7 @@
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 #include "hb.h"
+#include "patch_subset/codepoint_mapper.h"
 #include "patch_subset/compressed_set.h"
 #include "patch_subset/fake_subsetter.h"
 #include "patch_subset/hb_set_unique_ptr.h"
@@ -49,7 +50,8 @@ class PatchSubsetServerImplTest : public ::testing::Test {
         server_(std::unique_ptr<FontProvider>(font_provider_),
                 std::unique_ptr<Subsetter>(new FakeSubsetter()),
                 std::unique_ptr<BinaryDiff>(binary_diff_),
-                std::unique_ptr<Hasher>(hasher_)),
+                std::unique_ptr<Hasher>(hasher_),
+                std::unique_ptr<CodepointMapper>(nullptr)),
         set_abcd_(make_hb_set_from_ranges(1, 0x61, 0x64)),
         set_ab_(make_hb_set_from_ranges(1, 0x61, 0x62)) {}
 

--- a/patch_subset/py/patch_subset_session.cc
+++ b/patch_subset/py/patch_subset_session.cc
@@ -11,6 +11,7 @@
 #include "patch_subset/brotli_binary_patch.h"
 #include "patch_subset/brotli_request_logger.h"
 #include "patch_subset/codepoint_mapper.h"
+#include "patch_subset/codepoint_mapping_checksum.h"
 #include "patch_subset/farm_hasher.h"
 #include "patch_subset/file_font_provider.h"
 #include "patch_subset/font_provider.h"
@@ -27,6 +28,7 @@ using ::patch_subset::BrotliBinaryPatch;
 using ::patch_subset::BrotliRequestLogger;
 using ::patch_subset::ClientState;
 using ::patch_subset::CodepointMapper;
+using ::patch_subset::CodepointMappingChecksum;
 using ::patch_subset::FarmHasher;
 using ::patch_subset::FileFontProvider;
 using ::patch_subset::FontProvider;
@@ -50,7 +52,8 @@ class PatchSubsetSession {
                 std::unique_ptr<Subsetter>(new HarfbuzzSubsetter()),
                 std::unique_ptr<BinaryDiff>(binary_diff_),
                 std::unique_ptr<Hasher>(new FarmHasher()),
-                std::unique_ptr<CodepointMapper>(nullptr)),
+                std::unique_ptr<CodepointMapper>(nullptr),
+                std::unique_ptr<CodepointMappingChecksum>(nullptr)),
         client_(&server_, &brotli_request_logger_,
                 std::unique_ptr<BinaryPatch>(binary_patch_),
                 std::unique_ptr<Hasher>(new FarmHasher())) {

--- a/patch_subset/py/patch_subset_session.cc
+++ b/patch_subset/py/patch_subset_session.cc
@@ -10,6 +10,7 @@
 #include "patch_subset/brotli_binary_diff.h"
 #include "patch_subset/brotli_binary_patch.h"
 #include "patch_subset/brotli_request_logger.h"
+#include "patch_subset/codepoint_mapper.h"
 #include "patch_subset/farm_hasher.h"
 #include "patch_subset/file_font_provider.h"
 #include "patch_subset/font_provider.h"
@@ -25,6 +26,7 @@ using ::patch_subset::BrotliBinaryDiff;
 using ::patch_subset::BrotliBinaryPatch;
 using ::patch_subset::BrotliRequestLogger;
 using ::patch_subset::ClientState;
+using ::patch_subset::CodepointMapper;
 using ::patch_subset::FarmHasher;
 using ::patch_subset::FileFontProvider;
 using ::patch_subset::FontProvider;
@@ -47,7 +49,8 @@ class PatchSubsetSession {
         server_(std::unique_ptr<FontProvider>(font_provider_),
                 std::unique_ptr<Subsetter>(new HarfbuzzSubsetter()),
                 std::unique_ptr<BinaryDiff>(binary_diff_),
-                std::unique_ptr<Hasher>(new FarmHasher())),
+                std::unique_ptr<Hasher>(new FarmHasher()),
+                std::unique_ptr<CodepointMapper>(nullptr)),
         client_(&server_, &brotli_request_logger_,
                 std::unique_ptr<BinaryPatch>(binary_patch_),
                 std::unique_ptr<Hasher>(new FarmHasher())) {

--- a/patch_subset/server_integration_test.cc
+++ b/patch_subset/server_integration_test.cc
@@ -1,6 +1,7 @@
 #include "gtest/gtest.h"
 #include "patch_subset/brotli_binary_diff.h"
 #include "patch_subset/brotli_binary_patch.h"
+#include "patch_subset/codepoint_mapper.h"
 #include "patch_subset/compressed_set.h"
 #include "patch_subset/farm_hasher.h"
 #include "patch_subset/file_font_provider.h"
@@ -24,7 +25,8 @@ class PatchSubsetServerIntegrationTest : public ::testing::Test {
         server_(std::unique_ptr<FontProvider>(font_provider_),
                 std::unique_ptr<Subsetter>(new HarfbuzzSubsetter()),
                 std::unique_ptr<BinaryDiff>(binary_diff_),
-                std::unique_ptr<Hasher>(new FarmHasher())) {
+                std::unique_ptr<Hasher>(new FarmHasher()),
+                std::unique_ptr<CodepointMapper>(nullptr)) {
     font_provider_->GetFont("Roboto-Regular.abcd.ttf", &roboto_abcd_);
     font_provider_->GetFont("Roboto-Regular.ab.ttf", &roboto_ab_);
   }

--- a/patch_subset/server_integration_test.cc
+++ b/patch_subset/server_integration_test.cc
@@ -2,6 +2,7 @@
 #include "patch_subset/brotli_binary_diff.h"
 #include "patch_subset/brotli_binary_patch.h"
 #include "patch_subset/codepoint_mapper.h"
+#include "patch_subset/codepoint_mapping_checksum.h"
 #include "patch_subset/compressed_set.h"
 #include "patch_subset/farm_hasher.h"
 #include "patch_subset/file_font_provider.h"
@@ -26,7 +27,8 @@ class PatchSubsetServerIntegrationTest : public ::testing::Test {
                 std::unique_ptr<Subsetter>(new HarfbuzzSubsetter()),
                 std::unique_ptr<BinaryDiff>(binary_diff_),
                 std::unique_ptr<Hasher>(new FarmHasher()),
-                std::unique_ptr<CodepointMapper>(nullptr)) {
+                std::unique_ptr<CodepointMapper>(nullptr),
+                std::unique_ptr<CodepointMappingChecksum>(nullptr)) {
     font_provider_->GetFont("Roboto-Regular.abcd.ttf", &roboto_abcd_);
     font_provider_->GetFont("Roboto-Regular.ab.ttf", &roboto_ab_);
   }

--- a/patch_subset/simple_codepoint_mapper.cc
+++ b/patch_subset/simple_codepoint_mapper.cc
@@ -1,0 +1,18 @@
+#include "patch_subset/simple_codepoint_mapper.h"
+
+#include "hb.h"
+
+namespace patch_subset {
+
+void SimpleCodepointMapper::ComputeMapping(
+    const hb_set_t& codepoints, std::vector<hb_codepoint_t>* mapping) const {
+  mapping->clear();
+  for (hb_codepoint_t cp = HB_SET_VALUE_INVALID;
+       hb_set_next(&codepoints, &cp);) {
+    // hb_set_t iterates in sorted order by default. So just push the codepoints
+    // in the set into the mapping in the default iteration order.
+    mapping->push_back(cp);
+  }
+}
+
+}  // namespace patch_subset

--- a/patch_subset/simple_codepoint_mapper.h
+++ b/patch_subset/simple_codepoint_mapper.h
@@ -1,0 +1,26 @@
+#ifndef PATCH_SUBSET_SIMPLE_CODEPOINT_MAPPER_H_
+#define PATCH_SUBSET_SIMPLE_CODEPOINT_MAPPER_H_
+
+#include <vector>
+
+#include "hb.h"
+#include "patch_subset/codepoint_mapper.h"
+
+namespace patch_subset {
+
+// Computes a simple mapping where the codepoints
+// are sorted by value and then mapped to their
+// index in that sorting.
+class SimpleCodepointMapper : public CodepointMapper {
+ public:
+  SimpleCodepointMapper() {}
+
+  void ComputeMapping(const hb_set_t& codepoints,
+                      std::vector<hb_codepoint_t>* mapping) const override;
+
+ private:
+};
+
+}  // namespace patch_subset
+
+#endif  // PATCH_SUBSET_SIMPLE_CODEPOINT_MAPPER_H_

--- a/patch_subset/simple_codepoint_mapper_test.cc
+++ b/patch_subset/simple_codepoint_mapper_test.cc
@@ -1,0 +1,25 @@
+#include "patch_subset/simple_codepoint_mapper.h"
+
+#include "gtest/gtest.h"
+#include "patch_subset/hb_set_unique_ptr.h"
+
+namespace patch_subset {
+
+class SimpleCodepointMapperTest : public ::testing::Test {
+ protected:
+  SimpleCodepointMapperTest() {}
+
+  SimpleCodepointMapper codepoint_mapper_;
+};
+
+TEST_F(SimpleCodepointMapperTest, MapCodepoints) {
+  hb_set_unique_ptr codepoints = make_hb_set(4, 1, 7, 8, 11);
+
+  std::vector<hb_codepoint_t> mapping;
+  codepoint_mapper_.ComputeMapping(*codepoints, &mapping);
+
+  std::vector<hb_codepoint_t> expected = {1, 7, 8, 11};
+  EXPECT_EQ(mapping, expected);
+}
+
+}  // namespace patch_subset

--- a/patch_subset/subsetter.h
+++ b/patch_subset/subsetter.h
@@ -17,6 +17,11 @@ class Subsetter {
   // 'subset'.
   virtual StatusCode Subset(const FontData& font, const hb_set_t& codepoints,
                             FontData* subset /* OUT */) const = 0;
+
+  // Writes the set of all unicode codepoints that are in font to
+  // the codepoints set.
+  virtual void CodepointsInFont(const FontData& font,
+                                hb_set_t* codepoints) const = 0;
 };
 
 }  // namespace patch_subset


### PR DESCRIPTION
The codepoint remapping instructs the client how to remap codepoint values for future requests. See the design doc: https://docs.google.com/document/d/1DJ6VkUEZS2kvYZemIoX4fjCgqFXAtlRjpMlkOvblSts/edit for more details.

Currently, this PR only implements providing the remapping. It does not yet add the ability for the server to understand requests using the re-mapped codepoints.