### PR TITLE
Add support for computing costs for logged request/response sizes

### DIFF
--- a/analysis/analyzer.py
+++ b/analysis/analyzer.py
@@ -24,6 +24,7 @@ from analysis import network_models
 from analysis import page_view_sequence_pb2
 from analysis import result_pb2
 from analysis import simulation
+from analysis.pfe_methods import logged_pfe_method
 from analysis.pfe_methods import optimal_pfe_method
 from analysis.pfe_methods import unicode_range_pfe_method
 from analysis.pfe_methods import whole_font_pfe_method
@@ -211,6 +212,9 @@ def main(argv):
     data_set = read_binary_input(input_data_path)
   else:
     data_set = read_text_input(input_data_path)
+
+  if data_set.logged_method_name:
+    PFE_METHODS.append(logged_pfe_method.for_name(data_set.logged_method_name))
 
   LOG.info("Preparing input data.")
   # the sequence proto's need to be serialized since they are being

--- a/analysis/page_view_sequence.proto
+++ b/analysis/page_view_sequence.proto
@@ -1,5 +1,4 @@
-// Proto definition of the input data set for the analyis.
-// Used to represent sequences of page views.
+// Proto format used by the open source incxfer analysis code.
 syntax = "proto3";
 
 package analysis;
@@ -7,6 +6,19 @@ package analysis;
 message PageContentProto {
   string font_name = 1;
   repeated uint32 codepoints = 2;
+
+  // This is used to add data from logs of existing PFE method(s).
+  // Records the resulting request/response sizes incurred by that
+  // method for this page view.
+  //
+  // The analysis will generate costs for this method along with
+  // the simulated methods.
+  repeated PfeRequest logged_requests = 3;
+}
+
+message PfeRequest {
+  uint32 request_size = 1;
+  uint32 response_size = 2;
 }
 
 message PageViewProto {
@@ -19,4 +31,8 @@ message PageViewSequenceProto {
 
 message DataSetProto {
   repeated PageViewSequenceProto sequences = 1;
+
+  // If logged requests are included this is the name
+  // of the PFE_method they came from.
+  string logged_method_name = 2;
 }

--- a/analysis/pfe_methods/BUILD
+++ b/analysis/pfe_methods/BUILD
@@ -1,6 +1,7 @@
 py_library(
     name = "pfe_methods",
     srcs = [
+        "logged_pfe_method.py",
         "optimal_pfe_method.py",
         "subset_sizer.py",
         "unicode_range_pfe_method.py",
@@ -50,6 +51,16 @@ py_test(
     ],
     data = [
         "//patch_subset:testdata",
+    ],
+    deps = [
+        ":pfe_methods",
+    ],
+)
+
+py_test(
+    name = "logged_pfe_method_test",
+    srcs = [
+        "logged_pfe_method_test.py",
     ],
     deps = [
         ":pfe_methods",

--- a/analysis/pfe_methods/logged_pfe_method.py
+++ b/analysis/pfe_methods/logged_pfe_method.py
@@ -1,0 +1,48 @@
+"""This PFE method calculates response and request sizes using pre-recorded sizes
+that are specified in the input data.
+"""
+
+from analysis import request_graph
+
+
+def for_name(log_source):
+  return LoggedPfeMethod(log_source)
+
+
+class LoggedPfeMethod:
+  """Logged PFE Method."""
+
+  def __init__(self, log_source):
+    self.log_source = log_source
+
+  def name(self):
+    return self.log_source
+
+  def start_session(self, font_loader):  # pylint: disable=unused-argument,no-self-use
+    return LoggedPfeSession()
+
+
+class LoggedPfeSession:
+  """Logged PFE session."""
+
+  def __init__(self):
+    self.request_graphs = []
+
+  def page_view_proto(self, page_view):
+    """Processes a page view."""
+    requests = set()
+
+    for content in page_view.contents:
+      previous_request = None
+      for logged_request in content.logged_requests:
+        happens_after = None if previous_request is None else {previous_request}
+        next_request = request_graph.Request(logged_request.request_size,
+                                             logged_request.response_size,
+                                             happens_after=happens_after)
+        requests.add(next_request)
+        previous_request = next_request
+
+    self.request_graphs.append(request_graph.RequestGraph(requests))
+
+  def get_request_graphs(self):
+    return self.request_graphs

--- a/analysis/pfe_methods/logged_pfe_method_test.py
+++ b/analysis/pfe_methods/logged_pfe_method_test.py
@@ -1,0 +1,89 @@
+"""Unit tests for the logged_pfe_method module."""
+
+import unittest
+from analysis import page_view_sequence_pb2
+from analysis import request_graph
+from analysis.pfe_methods import logged_pfe_method
+
+
+class LoggedPfeMethodTest(unittest.TestCase):
+
+  def setUp(self):
+    self.session = logged_pfe_method.for_name("Method_Name").start_session(None)
+
+  def test_name(self):
+    self.assertEqual(
+        logged_pfe_method.for_name("Method_Name").name(), "Method_Name")
+
+  def test_no_requests(self):
+    page_view = page_view_sequence_pb2.PageViewProto()
+    page_view.contents.add()
+
+    self.session.page_view_proto(page_view)
+    self.session.page_view_proto(page_view)
+
+    graphs = self.session.get_request_graphs()
+    self.assertEqual(len(graphs), 2)
+
+    self.assertTrue(request_graph.graph_has_independent_requests(graphs[0], []))
+    self.assertTrue(request_graph.graph_has_independent_requests(graphs[1], []))
+
+  def test_single_requests(self):
+    page_view = page_view_sequence_pb2.PageViewProto()
+    content = page_view.contents.add()
+    logged_request = content.logged_requests.add()
+    logged_request.request_size = 123
+    logged_request.response_size = 456
+
+    self.session.page_view_proto(page_view)
+    self.session.page_view_proto(page_view)
+
+    graphs = self.session.get_request_graphs()
+    self.assertEqual(len(graphs), 2)
+
+    self.assertTrue(
+        request_graph.graph_has_independent_requests(graphs[0], [(123, 456)]))
+    self.assertTrue(
+        request_graph.graph_has_independent_requests(graphs[1], [(123, 456)]))
+
+  def test_chained_requests(self):
+    page_view = page_view_sequence_pb2.PageViewProto()
+    content = page_view.contents.add()
+    logged_request = content.logged_requests.add()
+    logged_request.request_size = 12
+    logged_request.response_size = 34
+    logged_request = content.logged_requests.add()
+    logged_request.request_size = 56
+    logged_request.response_size = 78
+
+    self.session.page_view_proto(page_view)
+
+    graphs = self.session.get_request_graphs()
+    self.assertEqual(len(graphs), 1)
+
+    graph = graphs[0]
+    self.assertEqual(graph.length(), 2)
+    self.assertEqual(len(graph.requests_that_can_run(set())), 1)
+
+  def test_multiple_chained_requests(self):
+    page_view = page_view_sequence_pb2.PageViewProto()
+    content = page_view.contents.add()
+    logged_request = content.logged_requests.add()
+    logged_request.request_size = 12
+    logged_request.response_size = 34
+    content = page_view.contents.add()
+    logged_request = content.logged_requests.add()
+    logged_request.request_size = 56
+    logged_request.response_size = 78
+
+    self.session.page_view_proto(page_view)
+
+    graphs = self.session.get_request_graphs()
+    self.assertEqual(len(graphs), 1)
+    self.assertTrue(
+        request_graph.graph_has_independent_requests(graphs[0], [(12, 34),
+                                                                 (56, 78)]))
+
+
+if __name__ == '__main__':
+  unittest.main()

--- a/analysis/simulation.py
+++ b/analysis/simulation.py
@@ -67,13 +67,13 @@ def simulate_sequence(sequence, pfe_method, a_font_loader):
   Returns a request graph for each page view in the sequence.
   """
   session = pfe_method.start_session(a_font_loader)
-  dont_convert_proto = (hasattr(session, "page_view_proto") and callable(session.page_view_proto))
+  dont_convert_proto = (hasattr(session, "page_view_proto") and
+                        callable(session.page_view_proto))
   for page_view in sequence:
     if dont_convert_proto:
       session.page_view_proto(page_view)
     else:
       session.page_view(codepoints_by_font(page_view))
-
 
   return session.get_request_graphs()
 

--- a/analysis/simulation.py
+++ b/analysis/simulation.py
@@ -67,8 +67,13 @@ def simulate_sequence(sequence, pfe_method, a_font_loader):
   Returns a request graph for each page view in the sequence.
   """
   session = pfe_method.start_session(a_font_loader)
+  dont_convert_proto = (hasattr(session, "page_view_proto") and callable(session.page_view_proto))
   for page_view in sequence:
-    session.page_view(codepoints_by_font(page_view))
+    if dont_convert_proto:
+      session.page_view_proto(page_view)
+    else:
+      session.page_view(codepoints_by_font(page_view))
+
 
   return session.get_request_graphs()
 

--- a/analysis/simulation_test.py
+++ b/analysis/simulation_test.py
@@ -146,9 +146,10 @@ class SimulationTest(unittest.TestCase):
     a_font_loader = font_loader.FontLoader("fonts/are/here")
     self.assertEqual(
         simulation.simulate_sequence(self.page_view_sequence,
-                                     self.mock_logged_pfe_method, a_font_loader),
-        [self.graph_1])
-    self.mock_logged_pfe_method.start_session.assert_called_once_with(a_font_loader)
+                                     self.mock_logged_pfe_method,
+                                     a_font_loader), [self.graph_1])
+    self.mock_logged_pfe_method.start_session.assert_called_once_with(
+        a_font_loader)
     self.mock_logged_pfe_session.page_view_proto.assert_called()
     self.mock_logged_pfe_session.get_request_graphs.assert_called_once_with()
 

--- a/analysis/simulation_test.py
+++ b/analysis/simulation_test.py
@@ -150,7 +150,8 @@ class SimulationTest(unittest.TestCase):
                                      a_font_loader), [self.graph_1])
     self.mock_logged_pfe_method.start_session.assert_called_once_with(
         a_font_loader)
-    self.mock_logged_pfe_session.page_view_proto.assert_called()
+    self.mock_logged_pfe_session.page_view_proto.assert_has_calls(
+        [mock.call(page_view) for page_view in self.page_view_sequence])
     self.mock_logged_pfe_session.get_request_graphs.assert_called_once_with()
 
   def test_simulate_all(self):

--- a/analysis/simulation_test.py
+++ b/analysis/simulation_test.py
@@ -23,6 +23,15 @@ class MockPfeSession:  # pylint: disable=missing-class-docstring
     pass
 
 
+class MockLoggedPfeSession:  # pylint: disable=missing-class-docstring
+
+  def page_view_proto(self, proto):
+    pass
+
+  def get_request_graphs(self):
+    pass
+
+
 def sequence(views):
   """Helper to create a sequence of page view proto's."""
   result = []
@@ -72,6 +81,15 @@ class SimulationTest(unittest.TestCase):
     self.mock_pfe_session_2.page_view = mock.MagicMock()
     self.mock_pfe_session_2.get_request_graphs = mock.MagicMock(
         return_value=[graph_2] * 2)
+
+    self.mock_logged_pfe_method = MockPfeMethod()
+    self.mock_logged_pfe_session = MockLoggedPfeSession()
+    self.mock_logged_pfe_method.name = mock.MagicMock(return_value="Logged_PFE")
+    self.mock_logged_pfe_method.start_session = mock.MagicMock(
+        return_value=self.mock_logged_pfe_session)
+    self.mock_logged_pfe_session.page_view_proto = mock.MagicMock()
+    self.mock_logged_pfe_session.get_request_graphs = mock.MagicMock(
+        return_value=[self.graph_1])
 
     self.page_view_sequence = sequence([
         {
@@ -123,6 +141,16 @@ class SimulationTest(unittest.TestCase):
         mock.call({"open_sans": {10, 11, 12}})
     ])
     self.mock_pfe_session.get_request_graphs.assert_called_once_with()
+
+  def test_simulate_logged(self):
+    a_font_loader = font_loader.FontLoader("fonts/are/here")
+    self.assertEqual(
+        simulation.simulate_sequence(self.page_view_sequence,
+                                     self.mock_logged_pfe_method, a_font_loader),
+        [self.graph_1])
+    self.mock_logged_pfe_method.start_session.assert_called_once_with(a_font_loader)
+    self.mock_logged_pfe_session.page_view_proto.assert_called()
+    self.mock_logged_pfe_session.get_request_graphs.assert_called_once_with()
 
   def test_simulate_all(self):
     self.maxDiff = None  # pylint: disable=invalid-name


### PR DESCRIPTION
Add the ability to optional add request and response sizes to the input data. These will be treated as an additional PFE method and have costs computed for them.