### PR TITLE
Add client handling of codepoint remapping.

### DIFF
--- a/patch_subset/codepoint_map.cc
+++ b/patch_subset/codepoint_map.cc
@@ -101,4 +101,13 @@ StatusCode CodepointMap::Decode(hb_codepoint_t* cp) const {
   return ApplyMappingTo(decode_map, cp);
 }
 
+void CodepointMap::IntersectWithMappedCodepoints(hb_set_t* codepoints) const {
+  hb_set_unique_ptr mapped_codepoints = make_hb_set();
+  for (auto entry : encode_map) {
+    hb_set_add(mapped_codepoints.get(), entry.first);
+  }
+
+  hb_set_intersect(codepoints, mapped_codepoints.get());
+}
+
 }  // namespace patch_subset

--- a/patch_subset/codepoint_map.cc
+++ b/patch_subset/codepoint_map.cc
@@ -16,10 +16,16 @@ void CodepointMap::AddMapping(hb_codepoint_t from, hb_codepoint_t to) {
   decode_map[to] = from;
 }
 
-StatusCode CodepointMap::FromProto(const CodepointRemappingProto& proto) const {
-  // TODO(garretrieger): implement me!
-  LOG(WARNING) << "Not implemeneted yet.";
-  return StatusCode::kUnimplemented;
+void CodepointMap::FromProto(const CodepointRemappingProto& proto) {
+  Clear();
+
+  int index = 0;
+  int last_cp = 0;
+  for (int delta : proto.codepoint_ordering().deltas()) {
+    int cp = last_cp + delta;
+    AddMapping(cp, index++);
+    last_cp = cp;
+  }
 }
 
 StatusCode CodepointMap::ToProto(CodepointRemappingProto* proto) const {

--- a/patch_subset/codepoint_map.h
+++ b/patch_subset/codepoint_map.h
@@ -32,7 +32,7 @@ class CodepointMap {
 
   // Load the codepoint remapping specified in 'proto'. Replaces
   // any existing mappings currently in this object.
-  StatusCode FromProto(const CodepointRemappingProto& proto);
+  void FromProto(const CodepointRemappingProto& proto);
 
   // Serialize this mapping to a CodepointRemappingProto.
   StatusCode ToProto(CodepointRemappingProto* proto /* OUT */) const;

--- a/patch_subset/codepoint_map.h
+++ b/patch_subset/codepoint_map.h
@@ -54,6 +54,10 @@ class CodepointMap {
   // Restore encoded cp to it's original value.
   StatusCode Decode(hb_codepoint_t* cp /* IN/OUT */) const;
 
+  // Given a set of untransformed codepoints, intersects it
+  // with the set of codepoints that this mapping can map.
+  void IntersectWithMappedCodepoints(hb_set_t* codepoints) const;
+
  private:
   std::unordered_map<hb_codepoint_t, hb_codepoint_t> encode_map;
   std::unordered_map<hb_codepoint_t, hb_codepoint_t> decode_map;

--- a/patch_subset/codepoint_map.h
+++ b/patch_subset/codepoint_map.h
@@ -32,7 +32,7 @@ class CodepointMap {
 
   // Load the codepoint remapping specified in 'proto'. Replaces
   // any existing mappings currently in this object.
-  StatusCode FromProto(const CodepointRemappingProto& proto) const;
+  StatusCode FromProto(const CodepointRemappingProto& proto);
 
   // Serialize this mapping to a CodepointRemappingProto.
   StatusCode ToProto(CodepointRemappingProto* proto /* OUT */) const;

--- a/patch_subset/codepoint_map_test.cc
+++ b/patch_subset/codepoint_map_test.cc
@@ -98,6 +98,21 @@ TEST_F(CodepointMapTest, DecodeMissing) {
   EXPECT_EQ(StatusCode::kInvalidArgument, codepoint_map_.Decode(&missing_cp));
 }
 
+TEST_F(CodepointMapTest, Fromroto) {
+  CodepointRemappingProto proto;
+  // Encode 9, 5, 8:
+  proto.mutable_codepoint_ordering()->add_deltas(9);
+  proto.mutable_codepoint_ordering()->add_deltas(-4);
+  proto.mutable_codepoint_ordering()->add_deltas(3);
+
+  codepoint_map_.Clear();
+  codepoint_map_.FromProto(proto);
+
+  ExpectEncodes(9, 0);
+  ExpectEncodes(5, 1);
+  ExpectEncodes(8, 2);
+}
+
 TEST_F(CodepointMapTest, ToProto) {
   CodepointRemappingProto proto;
 

--- a/patch_subset/codepoint_map_test.cc
+++ b/patch_subset/codepoint_map_test.cc
@@ -112,4 +112,12 @@ TEST_F(CodepointMapTest, ToProto) {
   EXPECT_EQ(proto.codepoint_ordering().deltas(2), 1);
 }
 
+TEST_F(CodepointMapTest, IntersectWithMappedCodepoints) {
+  hb_set_unique_ptr codepoints = make_hb_set(2, 4, 7, 9);
+  codepoint_map_.IntersectWithMappedCodepoints(codepoints.get());
+
+  hb_set_unique_ptr expected = make_hb_set(2, 4, 7);
+  EXPECT_TRUE(hb_set_is_equal(codepoints.get(), expected.get()));
+}
+
 }  // namespace patch_subset

--- a/patch_subset/patch_subset.proto
+++ b/patch_subset/patch_subset.proto
@@ -70,5 +70,5 @@ message ClientState {
   string font_id = 1;
   bytes font_data = 2;
   uint64 original_font_fingerprint = 3;
-  // TODO(grieger): add codepoint remapping.
+  CodepointRemappingProto codepoint_remapping = 4;
 }

--- a/patch_subset/patch_subset_client.cc
+++ b/patch_subset/patch_subset_client.cc
@@ -68,12 +68,9 @@ StatusCode PatchSubsetClient::EncodeCodepoints(const ClientState& state,
   }
 
   CodepointMap map;
-  StatusCode result = map.FromProto(state.codepoint_remapping());
-  if (result != StatusCode::kOk) {
-    LOG(WARNING) << "Failed to load codepoint remapping proto.";
-    return result;
-  }
+  map.FromProto(state.codepoint_remapping());
 
+  StatusCode result;
   map.IntersectWithMappedCodepoints(codepoints_have);
   if ((result = map.Encode(codepoints_have)) != StatusCode::kOk) {
     LOG(WARNING) << "Failed to encode codepoints_have with the mapping.";

--- a/patch_subset/patch_subset_client.cc
+++ b/patch_subset/patch_subset_client.cc
@@ -154,6 +154,10 @@ void PatchSubsetClient::CreateRequest(const hb_set_t& codepoints_have,
   CompressedSetProto codepoints_needed_encoded;
   CompressedSet::Encode(codepoints_needed, &codepoints_needed_encoded);
   *request->mutable_codepoints_needed() = codepoints_needed_encoded;
+
+  if (state.has_codepoint_remapping()) {
+    request->set_index_fingerprint(state.codepoint_remapping().fingerprint());
+  }
 }
 
 void PatchSubsetClient::LogRequest(const PatchRequestProto& request,

--- a/patch_subset/patch_subset_client.h
+++ b/patch_subset/patch_subset_client.h
@@ -32,6 +32,10 @@ class PatchSubsetClient {
   StatusCode Extend(const hb_set_t& additional_codepoints, ClientState* state);
 
  private:
+  StatusCode EncodeCodepoints(const ClientState& state,
+                              hb_set_t* codepoints_have,
+                              hb_set_t* codepoints_needed);
+
   void CreateRequest(const hb_set_t& codepoints_have,
                      const hb_set_t& codepoints_needed,
                      const ClientState& state, PatchRequestProto* request);

--- a/patch_subset/patch_subset_client_test.cc
+++ b/patch_subset/patch_subset_client_test.cc
@@ -146,6 +146,8 @@ TEST_F(PatchSubsetClientTest, SendPatchRequest_WithCodepointMapping) {
 
   PatchRequestProto expected_request =
       CreateRequest(*codepoints_have_encoded, *codepoints_needed_encoded);
+  expected_request.set_index_fingerprint(13);
+
   ExpectRequest(expected_request);
   ExpectChecksum(roboto_ab_.str(), kBaseFingerprint);
 
@@ -160,6 +162,7 @@ TEST_F(PatchSubsetClientTest, SendPatchRequest_WithCodepointMapping) {
   state.set_font_data(roboto_ab_.data(), roboto_ab_.size());
   state.set_original_font_fingerprint(kOriginalFingerprint);
   map.ToProto(state.mutable_codepoint_remapping());
+  state.mutable_codepoint_remapping()->set_fingerprint(13);
 
   client_->Extend(*codepoints_needed, &state);
 }


### PR DESCRIPTION
Adds support to the client for receiving a codepoint remapping from the server and then applying that mapping to future requests.