### PR TITLE
Deliver glyph IDs along with code points to the methods

### DIFF
--- a/analysis/fake_pfe_method.py
+++ b/analysis/fake_pfe_method.py
@@ -37,7 +37,7 @@ class FakePfeSession:
   def __init__(self):
     self.page_view_count = 0
 
-  def page_view(self, codepoints_by_font):  # pylint: disable=no-self-use,unused-argument
+  def page_view(self, usage_by_font):  # pylint: disable=no-self-use,unused-argument
     """Processes a page view.
 
     Where one or more fonts are used to render a set of codepoints.

--- a/analysis/pfe_methods/optimal_one_font_method.py
+++ b/analysis/pfe_methods/optimal_one_font_method.py
@@ -32,13 +32,13 @@ class OptimalOneFontSession:
     self.codepoints_by_font = dict()
     self.page_view_count = 0
 
-  def page_view(self, codepoints_by_font):
+  def page_view(self, usage_by_font):
     """Processes a page view."""
     self.page_view_count += 1
-    for font_id, codepoints in codepoints_by_font.items():
+    for font_id, usage in usage_by_font.items():
       # Load the font so an exception will be raised if it doesn't exist.
       self.font_loader.load_font(font_id)
-      self.page_view_for_font(font_id, codepoints)
+      self.page_view_for_font(font_id, usage.codepoints)
 
   def page_view_for_font(self, font_id, codepoints):
     """Processes a page for for a single font."""

--- a/analysis/pfe_methods/optimal_one_font_method_test.py
+++ b/analysis/pfe_methods/optimal_one_font_method_test.py
@@ -4,7 +4,12 @@ import unittest
 from analysis.pfe_methods import optimal_one_font_method
 from analysis import font_loader
 from analysis import request_graph
+from collections import namedtuple
 
+
+def u(codepoints):
+  usage = namedtuple("Usage", ["codepoints", "glyph_ids"])
+  return usage(codepoints, None)
 
 class MockSubsetSizer:
 
@@ -20,17 +25,17 @@ class OptimalOneFontMethodTest(unittest.TestCase):
 
   def test_font_not_found(self):
     with self.assertRaises(IOError):
-      self.session.page_view({"Roboto-Bold.ttf": [0x61, 0x62]})
+      self.session.page_view({"Roboto-Bold.ttf": u([0x61, 0x62])})
 
   def test_no_codepoints(self):
-    self.session.page_view({"Roboto-Regular.ttf": []})
+    self.session.page_view({"Roboto-Regular.ttf": u([])})
 
     graphs = self.session.get_request_graphs()
     self.assertEqual(len(graphs), 1)
     self.assertTrue(request_graph.graph_has_independent_requests(graphs[0], []))
 
   def test_one_page_view(self):
-    self.session.page_view({"Roboto-Regular.ttf": [1, 2, 3]})
+    self.session.page_view({"Roboto-Regular.ttf": u([1, 2, 3])})
 
     graphs = self.session.get_request_graphs()
     self.assertEqual(len(graphs), 1)
@@ -40,10 +45,10 @@ class OptimalOneFontMethodTest(unittest.TestCase):
         ]))
 
   def test_multiple_pageviews(self):
-    self.session.page_view({"Roboto-Regular.ttf": [1, 2, 3]})
-    self.session.page_view({"Roboto-Regular.ttf": [4, 5]})
-    self.session.page_view({"Roboto-Regular.ttf": [1, 2, 3]})
-    self.session.page_view({"Roboto-Regular.ttf": [1, 8]})
+    self.session.page_view({"Roboto-Regular.ttf": u([1, 2, 3])})
+    self.session.page_view({"Roboto-Regular.ttf": u([4, 5])})
+    self.session.page_view({"Roboto-Regular.ttf": u([1, 2, 3])})
+    self.session.page_view({"Roboto-Regular.ttf": u([1, 8])})
 
     graphs = self.session.get_request_graphs()
     self.assertEqual(len(graphs), 4)
@@ -57,14 +62,14 @@ class OptimalOneFontMethodTest(unittest.TestCase):
 
   def test_multiple_fonts(self):
     self.session.page_view({
-        "Roboto-Regular.ttf": [1, 2, 3],
-        "NotoSansJP-Regular.otf": [3, 4],
+        "Roboto-Regular.ttf": u([1, 2, 3]),
+        "NotoSansJP-Regular.otf": u([3, 4]),
     })
     self.session.page_view({
-        "Roboto-Regular.ttf": [3, 4, 5],
+        "Roboto-Regular.ttf": u([3, 4, 5]),
     })
     self.session.page_view({
-        "NotoSansJP-Regular.otf": [1],
+        "NotoSansJP-Regular.otf": u([1]),
     })
 
     graphs = self.session.get_request_graphs()

--- a/analysis/pfe_methods/optimal_pfe_method.py
+++ b/analysis/pfe_methods/optimal_pfe_method.py
@@ -35,11 +35,11 @@ class OptimalPfeSession:
     self.codepoints_by_font = dict()
     self.subset_size_by_font = dict()
 
-  def page_view(self, codepoints_by_font):
+  def page_view(self, usage_by_font):
     """Processes a page view."""
     requests = set()
-    for font_id, codepoints in codepoints_by_font.items():
-      requests.update(self.page_view_for_font(font_id, codepoints))
+    for font_id, usage in usage_by_font.items():
+      requests.update(self.page_view_for_font(font_id, usage.codepoints))
 
     self.request_graphs.append(request_graph.RequestGraph(requests))
 

--- a/analysis/pfe_methods/optimal_pfe_method_test.py
+++ b/analysis/pfe_methods/optimal_pfe_method_test.py
@@ -4,7 +4,12 @@ import unittest
 from analysis.pfe_methods import optimal_pfe_method
 from analysis import font_loader
 from analysis import request_graph
+from collections import namedtuple
 
+
+def u(codepoints):
+  usage = namedtuple("Usage", ["codepoints", "glyph_ids"])
+  return usage(codepoints, None)
 
 class MockSubsetSizer:
 
@@ -26,17 +31,17 @@ class OptimalPfeMethodTest(unittest.TestCase):
 
   def test_font_not_found(self):
     with self.assertRaises(IOError):
-      self.session.page_view({"Roboto-Bold.ttf": [0x61, 0x62]})
+      self.session.page_view({"Roboto-Bold.ttf": u([0x61, 0x62])})
 
   def test_no_codepoints(self):
-    self.session.page_view({"Roboto-Regular.ttf": []})
+    self.session.page_view({"Roboto-Regular.ttf": u([])})
 
     graphs = self.session.get_request_graphs()
     self.assertEqual(len(graphs), 1)
     self.assertTrue(request_graph.graph_has_independent_requests(graphs[0], []))
 
   def test_one_page_view(self):
-    self.session.page_view({"Roboto-Regular.ttf": [1, 2, 3]})
+    self.session.page_view({"Roboto-Regular.ttf": u([1, 2, 3])})
 
     graphs = self.session.get_request_graphs()
     self.assertEqual(len(graphs), 1)
@@ -46,10 +51,10 @@ class OptimalPfeMethodTest(unittest.TestCase):
         ]))
 
   def test_multiple_pageviews(self):
-    self.session.page_view({"Roboto-Regular.ttf": [1, 2, 3]})
-    self.session.page_view({"Roboto-Regular.ttf": [4, 5]})
-    self.session.page_view({"Roboto-Regular.ttf": [1, 2, 3]})
-    self.session.page_view({"Roboto-Regular.ttf": [1, 8]})
+    self.session.page_view({"Roboto-Regular.ttf": u([1, 2, 3])})
+    self.session.page_view({"Roboto-Regular.ttf": u([4, 5])})
+    self.session.page_view({"Roboto-Regular.ttf": u([1, 2, 3])})
+    self.session.page_view({"Roboto-Regular.ttf": u([1, 8])})
 
     graphs = self.session.get_request_graphs()
     self.assertEqual(len(graphs), 4)
@@ -71,8 +76,8 @@ class OptimalPfeMethodTest(unittest.TestCase):
     session = optimal_pfe_method.start_session(
         font_loader.FontLoader("./patch_subset/testdata/"),
         InverseMockSubsetSizer())
-    session.page_view({"Roboto-Regular.ttf": [1, 2, 3]})
-    session.page_view({"Roboto-Regular.ttf": [4, 5]})
+    session.page_view({"Roboto-Regular.ttf": u([1, 2, 3])})
+    session.page_view({"Roboto-Regular.ttf": u([4, 5])})
 
     graphs = session.get_request_graphs()
     self.assertEqual(len(graphs), 2)
@@ -84,14 +89,14 @@ class OptimalPfeMethodTest(unittest.TestCase):
 
   def test_multiple_fonts(self):
     self.session.page_view({
-        "Roboto-Regular.ttf": [1, 2, 3],
-        "NotoSansJP-Regular.otf": [3, 4],
+        "Roboto-Regular.ttf": u([1, 2, 3]),
+        "NotoSansJP-Regular.otf": u([3, 4]),
     })
     self.session.page_view({
-        "Roboto-Regular.ttf": [3, 4, 5],
+        "Roboto-Regular.ttf": u([3, 4, 5]),
     })
     self.session.page_view({
-        "NotoSansJP-Regular.otf": [1],
+        "NotoSansJP-Regular.otf": u([1]),
     })
 
     graphs = self.session.get_request_graphs()

--- a/analysis/pfe_methods/range_request_pfe_method.py
+++ b/analysis/pfe_methods/range_request_pfe_method.py
@@ -166,17 +166,17 @@ class RangeRequestPfeSession:
     starting_index = 0
     return payload_start, payload_end, extra_start, extra_end, starting_index
 
-  def page_view(self, codepoints_by_font):
+  def page_view(self, usage_by_font):
     requests = set()
     base_requests = dict()
     necessary_glyphs = defaultdict(set)
-    for font_id, codepoints in codepoints_by_font.items():
+    for font_id, usage in usage_by_font.items():
       if font_id not in GLYPH_DATA_CACHE:
         GLYPH_DATA_CACHE[font_id] = self.compute_glyph_data(font_id)
       font_data, glyph_data = GLYPH_DATA_CACHE[font_id]
 
       needs_base_request = font_id not in self.loaded_glyphs
-      glyphs = codepoints_to_glyphs(self.font_loader.load_font(font_id), codepoints)
+      glyphs = codepoints_to_glyphs(self.font_loader.load_font(font_id), usage.codepoints)
       present_glyphs = self.loaded_glyphs[font_id]
       glyphs_to_download = set([glyph for glyph in glyphs if glyph not in present_glyphs])
 

--- a/analysis/pfe_methods/range_request_pfe_method_test.py
+++ b/analysis/pfe_methods/range_request_pfe_method_test.py
@@ -4,8 +4,14 @@ import unittest
 from analysis import font_loader
 from analysis import request_graph
 from analysis.pfe_methods import range_request_pfe_method
+from collections import namedtuple
+
 
 GlyphRange = range_request_pfe_method.RangeRequestPfeSession.GlyphRange
+
+def u(codepoints):
+  usage = namedtuple("Usage", ["codepoints", "glyph_ids"])
+  return usage(codepoints, None)
 
 class RangeRequestPfeMethodTest(unittest.TestCase):
 
@@ -15,7 +21,7 @@ class RangeRequestPfeMethodTest(unittest.TestCase):
 
   def test_font_not_found(self):
     with self.assertRaises(IOError):
-      self.session.page_view({"Roboto-Bold.ttf": [0x61, 0x62]})
+      self.session.page_view({"Roboto-Bold.ttf": u([0x61, 0x62])})
 
   def test_compute_glyph_sizes(self):
     font_data, glyph_data = self.session.compute_glyph_data("Ahem.optimized.ttf")
@@ -222,7 +228,7 @@ class RangeRequestPfeMethodTest(unittest.TestCase):
     self.assertTrue(starting_index == 0 or starting_index == 1)
 
   def test_page_view_adjacent(self):
-    self.session.page_view({"Ahem.optimized.ttf": [0x37, 0x38]}) # These glyphs just happen to be next to each other
+    self.session.page_view({"Ahem.optimized.ttf": u([0x37, 0x38])}) # These glyphs just happen to be next to each other
     graphs = self.session.get_request_graphs()
     self.assertEqual(len(graphs), 1)
     self.assertEqual(len(graphs[0].requests), 2)
@@ -233,7 +239,7 @@ class RangeRequestPfeMethodTest(unittest.TestCase):
     self.assertTrue(len(requests[0].happens_after) == 1 or len(requests[1].happens_after) == 1)
 
   def test_page_view_disparate(self):
-    self.session.page_view({"Ahem.optimized.ttf": [0x61, 0x7A]})
+    self.session.page_view({"Ahem.optimized.ttf": u([0x61, 0x7A])})
     graphs = self.session.get_request_graphs()
     self.assertEqual(len(graphs), 1)
     self.assertEqual(len(graphs[0].requests), 3)
@@ -250,8 +256,8 @@ class RangeRequestPfeMethodTest(unittest.TestCase):
     self.assertEqual(happens_after_count, 2)
 
   def test_page_view_multiple(self):
-    self.session.page_view({"Ahem.optimized.ttf": [0x61]})
-    self.session.page_view({"Ahem.optimized.ttf": [0x7A]})
+    self.session.page_view({"Ahem.optimized.ttf": u([0x61])})
+    self.session.page_view({"Ahem.optimized.ttf": u([0x7A])})
     graphs = self.session.get_request_graphs()
     self.assertEqual(len(graphs), 2)
     self.assertEqual(len(graphs[0].requests), 2)
@@ -271,15 +277,15 @@ class RangeRequestPfeMethodTest(unittest.TestCase):
     self.assertEqual(happens_after_count, 1)
 
   def test_page_view_duplicate(self):
-    self.session.page_view({"Ahem.optimized.ttf": [0x61]})
-    self.session.page_view({"Ahem.optimized.ttf": [0x61]})
+    self.session.page_view({"Ahem.optimized.ttf": u([0x61])})
+    self.session.page_view({"Ahem.optimized.ttf": u([0x61])})
     graphs = self.session.get_request_graphs()
     self.assertEqual(len(graphs), 2)
     self.assertEqual(len(graphs[0].requests), 2)
     self.assertEqual(len(graphs[1].requests), 0)
 
   def test_page_view_not_present(self):
-    self.session.page_view({"Ahem.optimized.ttf": [0x623]})
+    self.session.page_view({"Ahem.optimized.ttf": u([0x623])})
     graphs = self.session.get_request_graphs()
     self.assertEqual(len(graphs), 1)
     self.assertEqual(len(graphs[0].requests), 0)

--- a/analysis/pfe_methods/unicode_range_pfe_method.py
+++ b/analysis/pfe_methods/unicode_range_pfe_method.py
@@ -51,11 +51,11 @@ class UnicodeRangePfeSession:
     self.request_graphs = []
     self.already_loaded_subsets = set()
 
-  def page_view(self, codepoints_by_font):
+  def page_view(self, usage_by_font):
     """Processes a page view."""
     requests = set()
-    for font_id, codepoints in codepoints_by_font.items():
-      requests.update(self.page_view_for_font(font_id, codepoints))
+    for font_id, usage in usage_by_font.items():
+      requests.update(self.page_view_for_font(font_id, usage.codepoints))
 
     self.request_graphs.append(request_graph.RequestGraph(requests))
 

--- a/analysis/pfe_methods/unicode_range_pfe_method_test.py
+++ b/analysis/pfe_methods/unicode_range_pfe_method_test.py
@@ -4,7 +4,12 @@ import unittest
 from analysis.pfe_methods import unicode_range_pfe_method
 from analysis import font_loader
 from analysis import request_graph
+from collections import namedtuple
 
+
+def u(codepoints):
+  usage = namedtuple("Usage", ["codepoints", "glyph_ids"])
+  return usage(codepoints, None)
 
 class MockSubsetSizer:
 
@@ -20,17 +25,17 @@ class UnicodeRangePfeMethodTest(unittest.TestCase):
 
   def test_font_not_found(self):
     with self.assertRaises(IOError):
-      self.session.page_view({"Roboto-Bold.ttf": [0x61, 0x62]})
+      self.session.page_view({"Roboto-Bold.ttf": u([0x61, 0x62])})
 
   def test_single_font_no_subsets(self):
-    self.session.page_view({"Roboto-Regular.ttf": [12345]})
+    self.session.page_view({"Roboto-Regular.ttf": u([12345])})
 
     graphs = self.session.get_request_graphs()
     self.assertEqual(len(graphs), 1)
     self.assertTrue(request_graph.graph_has_independent_requests(graphs[0], []))
 
   def test_single_font_one_subset(self):
-    self.session.page_view({"Roboto-Regular.ttf": [0x61, 0x62]})
+    self.session.page_view({"Roboto-Regular.ttf": u([0x61, 0x62])})
 
     graphs = self.session.get_request_graphs()
     self.assertEqual(len(graphs), 1)
@@ -40,7 +45,7 @@ class UnicodeRangePfeMethodTest(unittest.TestCase):
         ]))
 
   def test_single_font_multiple_subsets(self):
-    self.session.page_view({"Roboto-Regular.ttf": [0x61, 0x62, 0x040E, 0x0474]})
+    self.session.page_view({"Roboto-Regular.ttf": u([0x61, 0x62, 0x040E, 0x0474])})
 
     graphs = self.session.get_request_graphs()
     self.assertEqual(len(graphs), 1)
@@ -52,9 +57,9 @@ class UnicodeRangePfeMethodTest(unittest.TestCase):
         ]))
 
   def test_single_font_caches_subsets(self):
-    self.session.page_view({"Roboto-Regular.ttf": [0x61, 0x62, 0x0474]})
-    self.session.page_view({"Roboto-Regular.ttf": [0x63, 0x0475]})
-    self.session.page_view({"Roboto-Regular.ttf": [0x040E]})
+    self.session.page_view({"Roboto-Regular.ttf": u([0x61, 0x62, 0x0474])})
+    self.session.page_view({"Roboto-Regular.ttf": u([0x63, 0x0475])})
+    self.session.page_view({"Roboto-Regular.ttf": u([0x040E])})
 
     graphs = self.session.get_request_graphs()
     self.assertEqual(len(graphs), 3)
@@ -71,8 +76,8 @@ class UnicodeRangePfeMethodTest(unittest.TestCase):
 
   def test_multiple_fonts(self):
     self.session.page_view({
-        "Roboto-Regular.ttf": [0x61, 0x62],
-        "NotoSansJP-Regular.otf": [0x61, 155352],
+        "Roboto-Regular.ttf": u([0x61, 0x62]),
+        "NotoSansJP-Regular.otf": u([0x61, 155352]),
     })
 
     graphs = self.session.get_request_graphs()
@@ -86,14 +91,14 @@ class UnicodeRangePfeMethodTest(unittest.TestCase):
 
   def test_multiple_fonts_caches_subsets(self):
     self.session.page_view({
-        "Roboto-Regular.ttf": [0x61, 0x62],
+        "Roboto-Regular.ttf": u([0x61, 0x62]),
     })
     self.session.page_view({
-        "NotoSansJP-Regular.otf": [0x61, 0x62],
+        "NotoSansJP-Regular.otf": u([0x61, 0x62]),
     })
     self.session.page_view({
-        "Roboto-Regular.ttf": [0x63],
-        "NotoSansJP-Regular.otf": [0x63],
+        "Roboto-Regular.ttf": u([0x63]),
+        "NotoSansJP-Regular.otf": u([0x63]),
     })
 
     graphs = self.session.get_request_graphs()

--- a/analysis/pfe_methods/whole_font_pfe_method.py
+++ b/analysis/pfe_methods/whole_font_pfe_method.py
@@ -29,15 +29,15 @@ class WholeFontPfeSession:
     self.request_graphs = []
     self.loaded_fonts = set()
 
-  def page_view(self, codepoints_by_font):
+  def page_view(self, usage_by_font):
     """Processes a page view.
 
     For each font referenced in the page view record a request to
     load it if it has not been encountered yet.
     """
     requests = set()
-    for font_id, codepoints in codepoints_by_font.items():
-      if font_id in self.loaded_fonts or not codepoints:
+    for font_id, usage in usage_by_font.items():
+      if font_id in self.loaded_fonts or not usage or not usage.codepoints:
         continue
 
       self.loaded_fonts.add(font_id)

--- a/analysis/pfe_methods/whole_font_pfe_method_test.py
+++ b/analysis/pfe_methods/whole_font_pfe_method_test.py
@@ -4,10 +4,15 @@ import unittest
 from analysis import font_loader
 from analysis import request_graph
 from analysis.pfe_methods import whole_font_pfe_method
+from collections import namedtuple
 
 ROBOTO_REGULAR_WOFF2_SIZE = 64736
 ROBOTO_THIN_WOFF2_SIZE = 62908
 
+
+def u(codepoints):
+  usage = namedtuple("Usage", ["codepoints", "glyph_ids"])
+  return usage(codepoints, None)
 
 class WholeFontPfeMethodTest(unittest.TestCase):
 
@@ -17,10 +22,10 @@ class WholeFontPfeMethodTest(unittest.TestCase):
 
   def test_font_not_found(self):
     with self.assertRaises(IOError):
-      self.session.page_view({"Roboto-Bold.ttf": [0x61, 0x62]})
+      self.session.page_view({"Roboto-Bold.ttf": u([0x61, 0x62])})
 
   def test_single_file_load(self):
-    self.session.page_view({"Roboto-Regular.ttf": [0x61, 0x62]})
+    self.session.page_view({"Roboto-Regular.ttf": u([0x61, 0x62])})
 
     graphs = self.session.get_request_graphs()
     self.assertEqual(len(graphs), 1)
@@ -32,10 +37,10 @@ class WholeFontPfeMethodTest(unittest.TestCase):
   def test_cached_file_load(self):
     session = whole_font_pfe_method.start_session(
         font_loader.FontLoader("./patch_subset/testdata/"))
-    session.page_view({"Roboto-Regular.ttf": [0x61, 0x62]})
+    session.page_view({"Roboto-Regular.ttf": u([0x61, 0x62])})
     session = whole_font_pfe_method.start_session(
         font_loader.FontLoader("./patch_subset/testdata/"))
-    session.page_view({"Roboto-Regular.ttf": [0x63, 0x64]})
+    session.page_view({"Roboto-Regular.ttf": u([0x63, 0x64])})
 
     graphs = session.get_request_graphs()
     self.assertEqual(len(graphs), 1)
@@ -45,8 +50,8 @@ class WholeFontPfeMethodTest(unittest.TestCase):
         ]))
 
   def test_multiple_file_load(self):
-    self.session.page_view({"Roboto-Regular.ttf": [0x61, 0x62]})
-    self.session.page_view({"Roboto-Thin.ttf": [0x61, 0x62]})
+    self.session.page_view({"Roboto-Regular.ttf": u([0x61, 0x62])})
+    self.session.page_view({"Roboto-Thin.ttf": u([0x61, 0x62])})
 
     graphs = self.session.get_request_graphs()
     self.assertEqual(len(graphs), 2)
@@ -61,8 +66,8 @@ class WholeFontPfeMethodTest(unittest.TestCase):
 
   def test_parallel_file_loads(self):
     self.session.page_view({
-        "Roboto-Regular.ttf": [0x61, 0x62],
-        "Roboto-Thin.ttf": [0x61, 0x62],
+        "Roboto-Regular.ttf": u([0x61, 0x62]),
+        "Roboto-Thin.ttf": u([0x61, 0x62]),
     })
 
     graphs = self.session.get_request_graphs()
@@ -74,8 +79,8 @@ class WholeFontPfeMethodTest(unittest.TestCase):
         ]))
 
   def test_single_file_loads_only_once(self):
-    self.session.page_view({"Roboto-Regular.ttf": [0x61, 0x62]})
-    self.session.page_view({"Roboto-Regular.ttf": [0x63, 0x64]})
+    self.session.page_view({"Roboto-Regular.ttf": u([0x61, 0x62])})
+    self.session.page_view({"Roboto-Regular.ttf": u([0x63, 0x64])})
 
     graphs = self.session.get_request_graphs()
     self.assertEqual(len(graphs), 2)
@@ -86,7 +91,7 @@ class WholeFontPfeMethodTest(unittest.TestCase):
     self.assertTrue(request_graph.graph_has_independent_requests(graphs[1], []))
 
   def test_ignores_no_codepoint_font(self):
-    self.session.page_view({"Roboto-Regular.ttf": []})
+    self.session.page_view({"Roboto-Regular.ttf": u([])})
 
     graphs = self.session.get_request_graphs()
     self.assertEqual(len(graphs), 1)

--- a/analysis/simulation.py
+++ b/analysis/simulation.py
@@ -1,6 +1,7 @@
 """Functions for simulating various PFE methods across a data set."""
 
 import collections
+from collections import namedtuple
 import itertools
 
 from analysis import font_loader
@@ -74,7 +75,7 @@ def simulate_sequence(sequence, pfe_method, a_font_loader):
     if dont_convert_proto:
       session.page_view_proto(page_view)
     else:
-      session.page_view(codepoints_by_font(page_view))
+      session.page_view(usage_by_font(page_view))
 
   return session.get_request_graphs()
 
@@ -95,11 +96,14 @@ def total_time_for_request_graph(graph, network_model):
   return total_time
 
 
-def codepoints_by_font(page_view):
-  """For a page view computes a map from font name => codepoints."""
+def usage_by_font(page_view):
+  """For a page view computes a map from font name => (codepoints, glyphs)."""
   result = dict()
+  usage = namedtuple("Usage", ["codepoints", "glyph_ids"])
   for content in page_view.contents:
     codepoint_set = result.get(content.font_name, set())
     codepoint_set.update(content.codepoints)
-    result[content.font_name] = codepoint_set
+    glyph_set = result.get(content.font_name, set())
+    glyph_set.update(content.glyph_ids)
+    result[content.font_name] = usage(codepoint_set, glyph_set)
   return result

--- a/analysis/simulation_test.py
+++ b/analysis/simulation_test.py
@@ -6,6 +6,7 @@ from analysis import font_loader
 from analysis import page_view_sequence_pb2
 from analysis import request_graph
 from analysis import simulation
+from collections import namedtuple
 
 
 class MockPfeMethod:  # pylint: disable=missing-class-docstring
@@ -16,7 +17,7 @@ class MockPfeMethod:  # pylint: disable=missing-class-docstring
 
 class MockPfeSession:  # pylint: disable=missing-class-docstring
 
-  def page_view(self, codepoints_by_font):
+  def page_view(self, usage_by_font):
     pass
 
   def get_request_graphs(self):
@@ -130,15 +131,16 @@ class SimulationTest(unittest.TestCase):
                                      self.mock_pfe_method, a_font_loader),
         [self.graph_1])
     self.mock_pfe_method.start_session.assert_called_once_with(a_font_loader)
+    usage = namedtuple("Usage", ["codepoints", "glyph_ids"])
     self.mock_pfe_session.page_view.assert_has_calls([
         mock.call({
-            "roboto": {1, 2, 3},
-            "open_sans": {4, 5, 6},
+            "roboto": usage({1, 2, 3}, set()),
+            "open_sans": usage({4, 5, 6}, set()),
         }),
         mock.call({
-            "roboto": {7, 8, 9},
+            "roboto": usage({7, 8, 9}, set()),
         }),
-        mock.call({"open_sans": {10, 11, 12}})
+        mock.call({"open_sans": usage({10, 11, 12}, set())})
     ])
     self.mock_pfe_session.get_request_graphs.assert_called_once_with()
 

--- a/patch_subset/py/patch_subset_method.py
+++ b/patch_subset/py/patch_subset_method.py
@@ -185,23 +185,23 @@ class PatchSubsetPfeSession:
     self.font_loader = font_loader
     self.config = config
 
-  def page_view(self, codepoints_by_font):  # pylint: disable=no-self-use,unused-argument
+  def page_view(self, usage_by_font):  # pylint: disable=no-self-use,unused-argument
     """Processes a page view.
 
     Where one or more fonts are used to render a set of codepoints.
-    codepoints_by_font is a map from font name => a list of codepoints.
+    usage_by_font is a map from font name => a list of codepoints.
     """
     self.page_view_count += 1
     for session in self.sessions_by_font.values():
       session.page_viewed()
 
-    for font_id, codepoints in codepoints_by_font.items():
+    for font_id, usage in usage_by_font.items():
       if font_id not in self.sessions_by_font:
         self.sessions_by_font[font_id] = FontSession(self.font_loader, font_id,
                                                      self.page_view_count,
                                                      self.config)
 
-      self.sessions_by_font[font_id].extend(codepoints)
+      self.sessions_by_font[font_id].extend(usage.codepoints)
 
   def get_request_graphs(self):
     """Returns a graph of requests that would have resulted from the page views.

--- a/patch_subset/py/patch_subset_method_test.py
+++ b/patch_subset/py/patch_subset_method_test.py
@@ -6,7 +6,12 @@ import unittest
 from analysis import font_loader
 from fontTools import ttLib
 from patch_subset.py import patch_subset_method
+from collections import namedtuple
 
+
+def u(codepoints):
+  usage = namedtuple("Usage", ["codepoints", "glyph_ids"])
+  return usage(codepoints, None)
 
 class PatchSubsetMethodTest(unittest.TestCase):
 
@@ -21,12 +26,12 @@ class PatchSubsetMethodTest(unittest.TestCase):
 
   def test_font_not_found(self):
     with self.assertRaises(patch_subset_method.PatchSubsetError):
-      self.session.page_view({"Roboto-Bold.ttf": [0x61, 0x62]})
+      self.session.page_view({"Roboto-Bold.ttf": u([0x61, 0x62])})
 
   def test_session(self):
-    self.session.page_view({"Roboto-Regular.ttf": [0x61, 0x62]})
-    self.session.page_view({"Roboto-Regular.ttf": [0x61, 0x62, 0x63, 0x64]})
-    self.session.page_view({"Roboto-Regular.ttf": [0xAFFF]})
+    self.session.page_view({"Roboto-Regular.ttf": u([0x61, 0x62])})
+    self.session.page_view({"Roboto-Regular.ttf": u([0x61, 0x62, 0x63, 0x64])})
+    self.session.page_view({"Roboto-Regular.ttf": u([0xAFFF])})
 
     self.assertEqual(len(self.session.get_request_graphs()), 3)
     self.assertEqual(self.session.get_request_graphs()[0].length(), 1)
@@ -42,9 +47,9 @@ class PatchSubsetMethodTest(unittest.TestCase):
   def test_session_with_remapping(self):
     session = self.session_with_remapping
 
-    session.page_view({"Roboto-Regular.ttf": [0x61, 0x62]})
-    session.page_view({"Roboto-Regular.ttf": [0x61, 0x62, 0x63, 0x64]})
-    session.page_view({"Roboto-Regular.ttf": [0xAFFF]})
+    session.page_view({"Roboto-Regular.ttf": u([0x61, 0x62])})
+    session.page_view({"Roboto-Regular.ttf": u([0x61, 0x62, 0x63, 0x64])})
+    session.page_view({"Roboto-Regular.ttf": u([0xAFFF])})
 
     self.assertEqual(len(session.get_request_graphs()), 3)
     self.assertEqual(session.get_request_graphs()[0].length(), 1)
@@ -70,9 +75,9 @@ class PatchSubsetMethodTest(unittest.TestCase):
   def test_session_with_prediction(self):
     session = self.session_with_prediction
 
-    session.page_view({"Roboto-Regular.ttf": [0x61, 0x62]})
-    session.page_view({"Roboto-Regular.ttf": [0x61, 0x62, 0xA3]})
-    session.page_view({"Roboto-Regular.ttf": [0xAFFF]})
+    session.page_view({"Roboto-Regular.ttf": u([0x61, 0x62])})
+    session.page_view({"Roboto-Regular.ttf": u([0x61, 0x62, 0xA3])})
+    session.page_view({"Roboto-Regular.ttf": u([0xAFFF])})
 
     self.assertEqual(len(session.get_request_graphs()), 3)
     self.assertEqual(session.get_request_graphs()[0].length(), 1)
@@ -91,10 +96,10 @@ class PatchSubsetMethodTest(unittest.TestCase):
     self.assertTrue(0x64 in codepoints)
 
   def test_multi_font_session(self):
-    self.session.page_view({"Roboto-Regular.ttf": [0x61, 0x62]})
+    self.session.page_view({"Roboto-Regular.ttf": u([0x61, 0x62])})
     self.session.page_view({
-        "Roboto-Regular.ttf": [0x61, 0x62, 0x63, 0x64],
-        "Roboto-Regular.Awesome.ttf": [0x41]
+        "Roboto-Regular.ttf": u([0x61, 0x62, 0x63, 0x64]),
+        "Roboto-Regular.Awesome.ttf": u([0x41])
     })
 
     self.assertEqual(len(self.session.get_request_graphs()), 2)


### PR DESCRIPTION
This modifies `page_view()` in the methods to take a dictionary of objects, where each object holds a `codepoints` and `glyph_ids` field.

There is no behavior change; this doesn't modify the range request method to use the glyph IDs (yet).