### PR TITLE
Expose network parameters to the methods

### DIFF
--- a/analysis/analyzer.py
+++ b/analysis/analyzer.py
@@ -62,7 +62,7 @@ flags.DEFINE_list("filter_languages", None,
                   "List of language tags to filter the input data by.")
 
 PFE_METHODS = [
-    #range_request_pfe_method,
+    range_request_pfe_method,
     optimal_pfe_method,
     optimal_one_font_method,
     unicode_range_pfe_method,

--- a/analysis/fake_pfe_method.py
+++ b/analysis/fake_pfe_method.py
@@ -16,7 +16,7 @@ def name():
   return "Fake_PFE"
 
 
-def start_session(font_loader):  # pylint: disable=unused-argument
+def start_session(network_model, font_loader):  # pylint: disable=unused-argument
   """Starts a new PFE session for this method.
 
   A session tracks the enrichment of one or more fonts

--- a/analysis/pfe_methods/logged_pfe_method.py
+++ b/analysis/pfe_methods/logged_pfe_method.py
@@ -18,7 +18,7 @@ class LoggedPfeMethod:
   def name(self):
     return self.log_source
 
-  def start_session(self, font_loader):  # pylint: disable=unused-argument,no-self-use
+  def start_session(self, network_model, font_loader):  # pylint: disable=unused-argument,no-self-use
     return LoggedPfeSession()
 
 

--- a/analysis/pfe_methods/logged_pfe_method_test.py
+++ b/analysis/pfe_methods/logged_pfe_method_test.py
@@ -9,7 +9,7 @@ from analysis.pfe_methods import logged_pfe_method
 class LoggedPfeMethodTest(unittest.TestCase):
 
   def setUp(self):
-    self.session = logged_pfe_method.for_name("Method_Name").start_session(None)
+    self.session = logged_pfe_method.for_name("Method_Name").start_session(None, None)
 
   def test_name(self):
     self.assertEqual(

--- a/analysis/pfe_methods/optimal_one_font_method.py
+++ b/analysis/pfe_methods/optimal_one_font_method.py
@@ -17,7 +17,7 @@ def name():
   return "OptimalOneFont"
 
 
-def start_session(font_loader, a_subset_sizer=None):
+def start_session(network_model, font_loader, a_subset_sizer=None):
   return OptimalOneFontSession(font_loader, a_subset_sizer)
 
 

--- a/analysis/pfe_methods/optimal_one_font_method_test.py
+++ b/analysis/pfe_methods/optimal_one_font_method_test.py
@@ -20,7 +20,7 @@ class MockSubsetSizer:
 class OptimalOneFontMethodTest(unittest.TestCase):
 
   def setUp(self):
-    self.session = optimal_one_font_method.start_session(
+    self.session = optimal_one_font_method.start_session(None,
         font_loader.FontLoader("./patch_subset/testdata/"), MockSubsetSizer())
 
   def test_font_not_found(self):

--- a/analysis/pfe_methods/optimal_pfe_method.py
+++ b/analysis/pfe_methods/optimal_pfe_method.py
@@ -19,7 +19,7 @@ def name():
   return "Optimal"
 
 
-def start_session(font_loader, a_subset_sizer=None):
+def start_session(network_model, font_loader, a_subset_sizer=None):
   return OptimalPfeSession(font_loader, a_subset_sizer)
 
 

--- a/analysis/pfe_methods/optimal_pfe_method_test.py
+++ b/analysis/pfe_methods/optimal_pfe_method_test.py
@@ -26,7 +26,7 @@ class InverseMockSubsetSizer:
 class OptimalPfeMethodTest(unittest.TestCase):
 
   def setUp(self):
-    self.session = optimal_pfe_method.start_session(
+    self.session = optimal_pfe_method.start_session(None,
         font_loader.FontLoader("./patch_subset/testdata/"), MockSubsetSizer())
 
   def test_font_not_found(self):
@@ -73,7 +73,7 @@ class OptimalPfeMethodTest(unittest.TestCase):
         ]))
 
   def test_subsequent_subset_smaller(self):
-    session = optimal_pfe_method.start_session(
+    session = optimal_pfe_method.start_session(None,
         font_loader.FontLoader("./patch_subset/testdata/"),
         InverseMockSubsetSizer())
     session.page_view({"Roboto-Regular.ttf": u([1, 2, 3])})

--- a/analysis/pfe_methods/range_request_pfe_method.py
+++ b/analysis/pfe_methods/range_request_pfe_method.py
@@ -23,8 +23,8 @@ def name():
 # network_model.rtt * network_model.bandwidth_down
 # network_models.ESTIMATED_HTTP_REQUEST_HEADER_SIZE + network_models.ESTIMATED_HTTP_RESPONSE_HEADER_SIZE
 # Whatever it has to be such that (network_model.rtt * network_model.bandwidth_down) / len(requests) == network_startup_cost_in_bytes
-def start_session(font_loader, network_startup_cost_in_bytes=network_models.ESTIMATED_HTTP_REQUEST_HEADER_SIZE + network_models.ESTIMATED_HTTP_RESPONSE_HEADER_SIZE):
-  return RangeRequestPfeSession(font_loader, network_startup_cost_in_bytes)
+def start_session(network_model, font_loader, network_startup_cost_in_bytes=network_models.ESTIMATED_HTTP_REQUEST_HEADER_SIZE + network_models.ESTIMATED_HTTP_RESPONSE_HEADER_SIZE):
+  return RangeRequestPfeSession(network_model, font_loader, network_startup_cost_in_bytes)
 
 def codepoints_to_glyphs(font_bytes, codepoints):
   font = ttLib.TTFont(io.BytesIO(font_bytes))
@@ -36,8 +36,9 @@ class RangeRequestError(Exception):
 
 class RangeRequestPfeSession:
 
-  def __init__(self, font_loader, network_startup_cost_in_bytes):
+  def __init__(self, network_model, font_loader, network_startup_cost_in_bytes):
     # FIXME: network_startup_cost_in_bytes should be gathered from the actual network models.
+    self.network_model = network_model
     self.font_loader = font_loader
     self.network_startup_cost_in_bytes = network_startup_cost_in_bytes
     self.request_graphs = []

--- a/analysis/pfe_methods/range_request_pfe_method_test.py
+++ b/analysis/pfe_methods/range_request_pfe_method_test.py
@@ -16,7 +16,7 @@ def u(codepoints):
 class RangeRequestPfeMethodTest(unittest.TestCase):
 
   def setUp(self):
-    self.session = range_request_pfe_method.start_session(
+    self.session = range_request_pfe_method.start_session(None,
         font_loader.FontLoader("./patch_subset/testdata/"), 10)
 
   def test_font_not_found(self):

--- a/analysis/pfe_methods/unicode_range_pfe_method.py
+++ b/analysis/pfe_methods/unicode_range_pfe_method.py
@@ -25,7 +25,7 @@ def name():
   return "GoogleFonts_UnicodeRange"
 
 
-def start_session(font_loader, a_subset_sizer=None):
+def start_session(network_model, font_loader, a_subset_sizer=None):
   return UnicodeRangePfeSession(font_loader, a_subset_sizer)
 
 

--- a/analysis/pfe_methods/unicode_range_pfe_method_test.py
+++ b/analysis/pfe_methods/unicode_range_pfe_method_test.py
@@ -20,7 +20,7 @@ class MockSubsetSizer:
 class UnicodeRangePfeMethodTest(unittest.TestCase):
 
   def setUp(self):
-    self.session = unicode_range_pfe_method.start_session(
+    self.session = unicode_range_pfe_method.start_session(None,
         font_loader.FontLoader("./patch_subset/testdata/"), MockSubsetSizer())
 
   def test_font_not_found(self):

--- a/analysis/pfe_methods/whole_font_pfe_method.py
+++ b/analysis/pfe_methods/whole_font_pfe_method.py
@@ -17,7 +17,7 @@ def name():
   return "WholeFont"
 
 
-def start_session(font_loader):
+def start_session(network_model, font_loader):
   return WholeFontPfeSession(font_loader)
 
 

--- a/analysis/pfe_methods/whole_font_pfe_method_test.py
+++ b/analysis/pfe_methods/whole_font_pfe_method_test.py
@@ -17,7 +17,7 @@ def u(codepoints):
 class WholeFontPfeMethodTest(unittest.TestCase):
 
   def setUp(self):
-    self.session = whole_font_pfe_method.start_session(
+    self.session = whole_font_pfe_method.start_session(None,
         font_loader.FontLoader("./patch_subset/testdata/"))
 
   def test_font_not_found(self):
@@ -35,10 +35,10 @@ class WholeFontPfeMethodTest(unittest.TestCase):
         ]))
 
   def test_cached_file_load(self):
-    session = whole_font_pfe_method.start_session(
+    session = whole_font_pfe_method.start_session(None,
         font_loader.FontLoader("./patch_subset/testdata/"))
     session.page_view({"Roboto-Regular.ttf": u([0x61, 0x62])})
-    session = whole_font_pfe_method.start_session(
+    session = whole_font_pfe_method.start_session(None,
         font_loader.FontLoader("./patch_subset/testdata/"))
     session.page_view({"Roboto-Regular.ttf": u([0x63, 0x64])})
 

--- a/analysis/result.proto
+++ b/analysis/result.proto
@@ -13,11 +13,8 @@ message MethodResultProto {
 
   repeated NetworkResultProto results_by_network = 2;
 
-  reserved 3;
-  reserved 4;
-  reserved 5;
-  reserved 6;
-  reserved 7;
+  reserved 3 to 7;
+  reserved "request_bytes_per_page_view", "response_bytes_per_page_view", "total_request_count", "total_request_bytes", "total_response_bytes";
 }
 
 message NetworkResultProto {

--- a/analysis/result.proto
+++ b/analysis/result.proto
@@ -12,12 +12,12 @@ message MethodResultProto {
   string method_name = 1;
 
   repeated NetworkResultProto results_by_network = 2;
-  DistributionProto request_bytes_per_page_view = 3;
-  DistributionProto response_bytes_per_page_view = 4;
 
-  uint64 total_request_count = 5;
-  uint64 total_request_bytes = 6;
-  uint64 total_response_bytes = 7;
+  reserved 3;
+  reserved 4;
+  reserved 5;
+  reserved 6;
+  reserved 7;
 }
 
 message NetworkResultProto {
@@ -26,6 +26,13 @@ message NetworkResultProto {
   DistributionProto wait_per_page_view_ms = 3;
   DistributionProto cost_per_page_view = 4;
   double total_wait_time_ms = 5;
+
+  DistributionProto request_bytes_per_page_view = 6;
+  DistributionProto response_bytes_per_page_view = 7;
+
+  uint64 total_request_count = 8;
+  uint64 total_request_bytes = 9;
+  uint64 total_response_bytes = 10;
 }
 
 message DistributionProto {

--- a/analysis/simulation.py
+++ b/analysis/simulation.py
@@ -39,12 +39,23 @@ def simulate_all(sequences, pfe_methods, network_models, font_directory, default
   result = dict()
   for method in pfe_methods:
     model_totals = dict()
-    for network_model in network_models:
-      totals = []
+    if hasattr(method, "network_sensitive") and callable(method.network_sensitive) and method.network_sensitive():
+      for network_model in network_models:
+        totals = []
+        for sequence in sequences:
+          graphs = simulate_sequence(sequence, method, network_model, a_font_loader)
+          totals.extend(totals_for_network(graphs, network_model))
+        model_totals[network_model.name] = totals
+    else:
+      graph_collection = []
       for sequence in sequences:
-        graphs = simulate_sequence(sequence, method, network_model, a_font_loader)
-        totals.extend(totals_for_network(graphs, network_model))
-      model_totals[network_model.name] = totals
+        graphs = simulate_sequence(sequence, method, None, a_font_loader)
+        graph_collection.append(graphs)
+      for network_model in network_models:
+        totals = []
+        for graphs in graph_collection:
+          totals.extend(totals_for_network(graphs, network_model))
+        model_totals[network_model.name] = totals
     result[method.name()] = model_totals
   return result
 

--- a/analysis/simulation_test.py
+++ b/analysis/simulation_test.py
@@ -158,24 +158,22 @@ class SimulationTest(unittest.TestCase):
 
   def test_simulate_all(self):
     self.maxDiff = None  # pylint: disable=invalid-name
-    sequences = [
-        sequence([{
-            "roboto": [1]
-        }, {
-            "roboto": [2]
-        }]),
-        sequence([{
-            "roboto": [1]
-        }, {
-            "roboto": [2]
-        }]),
-    ]
-
     graph = simulation.GraphTotal(100.0, 1000, 1000, 1)
     graph2 = simulation.GraphTotal(200.0, 1000, 1000, 1)
     self.assertEqual(
         simulation.simulate_all(
-            sequences,
+            [
+                sequence([{
+                    "roboto": [1]
+                }, {
+                    "roboto": [2]
+                }]),
+                sequence([{
+                    "roboto": [1]
+                }, {
+                    "roboto": [2]
+                }]),
+            ],
             [
                 self.mock_pfe_method,
                 self.mock_pfe_method_2,

--- a/patch_subset/py/patch_subset_method.py
+++ b/patch_subset/py/patch_subset_method.py
@@ -78,7 +78,7 @@ class PatchSubsetMethod:
 
     return "PatchSubset_PFE%s" % modifiers
 
-  def start_session(self, font_loader):
+  def start_session(self, network_model, font_loader):
     """Starts a new PFE session for this method."""
     return PatchSubsetPfeSession(font_loader, self.config)
 

--- a/patch_subset/py/patch_subset_method_test.py
+++ b/patch_subset/py/patch_subset_method_test.py
@@ -17,12 +17,12 @@ class PatchSubsetMethodTest(unittest.TestCase):
 
   def setUp(self):
     self.session = patch_subset_method.create_without_codepoint_remapping(
-    ).start_session(font_loader.FontLoader("./patch_subset/testdata/"))
+    ).start_session(None, font_loader.FontLoader("./patch_subset/testdata/"))
     self.session_with_remapping = patch_subset_method.create_with_codepoint_remapping(
-    ).start_session(font_loader.FontLoader("./patch_subset/testdata/"))
+    ).start_session(None, font_loader.FontLoader("./patch_subset/testdata/"))
     self.session_with_prediction = patch_subset_method.create_with_codepoint_prediction(
         50,
-        0.0).start_session(font_loader.FontLoader("./patch_subset/testdata/"))
+        0.0).start_session(None, font_loader.FontLoader("./patch_subset/testdata/"))
 
   def test_font_not_found(self):
     with self.assertRaises(patch_subset_method.PatchSubsetError):

--- a/tools/summarize_results.py
+++ b/tools/summarize_results.py
@@ -153,7 +153,6 @@ def print_summary_report(result_proto):
 
   method name, network model name, total cost
   """
-  print(result_proto.results[0].method_name)
   print("Method, Network, Cost, Wait (ms), Number of Requests, Request Bytes, "
         "Response Bytes, Bytes, % of Optimal Bytes")
   optimal_bytes = None


### PR DESCRIPTION
This exposes the network parameters to the methods, by passing the parameters to the `start_session()` method. There is no behavior change in this patch: none of the methods actually use the network parameters (yet).

Previously, the computation of the network graphs were insensitive to the network parameters, which was reflected in the layout of the `AnalysisResultProto` output data structure. Now that different network parameters can result in different graphs, the layout of this output data structure is modified to put fields like `total_request_count` in the network-specific part.

This patch also updates the `summarize_results.py` script to properly understand this updated data structure.